### PR TITLE
[Feature] Implement user public profile backend with routes and follow state

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, url_for, request, session
+from flask import Flask, render_template, redirect, url_for, request, session, abort
 from functools import wraps
 from models import db, User
 from utils import hash_password, check_password
@@ -20,6 +20,11 @@ db.init_app(app)
 # ---------------------------------------------------------------------------
 
 def seed_demo_users():
+    """
+    데모 계정 (alex / mina / sam) 을 DB에 삽입한다.
+    이미 존재하는 계정은 건너뛴다.
+    비밀번호는 모두 'password123' 으로 통일 (데모용).
+    """
     demo_accounts = [
         {
             "username": "alex",
@@ -70,6 +75,10 @@ THEMES = ["first date", "picnic", "active day", "hidden gems"]
 # ---------------------------------------------------------------------------
 
 def current_user():
+    """
+    session["user_id"] 로 DB에서 User 객체를 조회해 반환한다.
+    세션이 없거나 DB에 없으면 None을 반환한다.
+    """
     user_id = session.get("user_id")
     if not user_id:
         return None
@@ -230,61 +239,85 @@ def change_password():
         new_pw     = request.form.get("newPassword",     "")
         confirm_pw = request.form.get("confirmPassword", "")
 
-        # --- 빈 칸 검사 ---
         if not current_pw:
             return render_template(
-                "change_password.html",
-                active_page="profile",
+                "change_password.html", active_page="profile",
                 error="Please enter your current password.",
             )
         if not new_pw:
             return render_template(
-                "change_password.html",
-                active_page="profile",
+                "change_password.html", active_page="profile",
                 error="Please enter a new password.",
             )
         if not confirm_pw:
             return render_template(
-                "change_password.html",
-                active_page="profile",
+                "change_password.html", active_page="profile",
                 error="Please confirm your new password.",
             )
-
-        # --- 현재 비밀번호 검증 ---
         if not check_password(current_pw, user.password_hash):
             return render_template(
-                "change_password.html",
-                active_page="profile",
+                "change_password.html", active_page="profile",
                 error="Current password is incorrect. Please try again.",
             )
-
-        # --- 새 비밀번호 검증 ---
         if len(new_pw) < 6:
             return render_template(
-                "change_password.html",
-                active_page="profile",
+                "change_password.html", active_page="profile",
                 error="New password must be at least 6 characters.",
             )
         if new_pw != confirm_pw:
             return render_template(
-                "change_password.html",
-                active_page="profile",
+                "change_password.html", active_page="profile",
                 error="New passwords do not match.",
             )
 
-        # --- DB 업데이트 ---
         user.password_hash = hash_password(new_pw)
         db.session.commit()
 
         return render_template(
-            "change_password.html",
-            active_page="profile",
+            "change_password.html", active_page="profile",
             success="Password updated successfully.",
         )
 
+    return render_template("change_password.html", active_page="profile")
+
+
+@app.route("/user/<username>")
+@login_required
+def user_profile(username):
+    """
+    유저 공개 프로필 페이지.
+    실제 팔로우 여부 및 루트 조회는 Issue 11에서 구현 예정.
+    현재는 DB에서 유저 정보만 조회하고 나머지는 placeholder.
+    """
+    me = current_user()
+
+    # 존재하지 않는 유저 접근 시 404
+    profile_user = User.query.filter_by(username=username).first()
+    if not profile_user:
+        abort(404)
+
+    # 본인 프로필 접근 시 /profile 로 리다이렉트
+    if me and me.id == profile_user.id:
+        return redirect(url_for("profile"))
+
+    # -----------------------------------------------------------------------
+    # Issue 11에서 실제 DB 조회로 교체 예정
+    # -----------------------------------------------------------------------
+    is_own_profile  = False
+    is_following    = False
+    follower_count  = 0
+    following_count = 0
+    user_routes     = []
+
     return render_template(
-        "change_password.html",
-        active_page="profile",
+        "user_profile.html",
+        active_page=None,
+        profile_user=profile_user,
+        is_own_profile=is_own_profile,
+        is_following=is_following,
+        follower_count=follower_count,
+        following_count=following_count,
+        user_routes=user_routes,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -20,11 +20,6 @@ db.init_app(app)
 # ---------------------------------------------------------------------------
 
 def seed_demo_users():
-    """
-    데모 계정 (alex / mina / sam) 을 DB에 삽입한다.
-    이미 존재하는 계정은 건너뛴다.
-    비밀번호는 모두 'password123' 으로 통일 (데모용).
-    """
     demo_accounts = [
         {
             "username": "alex",
@@ -65,7 +60,7 @@ with app.app_context():
     seed_demo_users()
 
 # ---------------------------------------------------------------------------
-# Mock data (기존 JS 프론트 호환용)
+# Mock data
 # ---------------------------------------------------------------------------
 
 THEMES = ["first date", "picnic", "active day", "hidden gems"]
@@ -75,10 +70,6 @@ THEMES = ["first date", "picnic", "active day", "hidden gems"]
 # ---------------------------------------------------------------------------
 
 def current_user():
-    """
-    session["user_id"] 로 DB에서 User 객체를 조회해 반환한다.
-    세션이 없거나 DB에 없으면 None을 반환한다.
-    """
     user_id = session.get("user_id")
     if not user_id:
         return None
@@ -87,11 +78,6 @@ def current_user():
 
 @app.context_processor
 def inject_template_globals():
-    """
-    모든 템플릿에 current_user 객체와 server_username을 주입한다.
-    - current_user    : User 객체 또는 None
-    - server_username : 기존 템플릿 호환용 문자열
-    """
     user = current_user()
     return {
         "current_user":    user,
@@ -100,10 +86,6 @@ def inject_template_globals():
 
 
 def login_required(f):
-    """
-    session["user_id"] 기준으로 인증 여부를 판단한다.
-    미인증 시 login 페이지로 리다이렉트한다.
-    """
     @wraps(f)
     def decorated(*args, **kwargs):
         if session.get("user_id") is None:
@@ -238,10 +220,68 @@ def profile():
     )
 
 
-@app.route("/change-password", methods=["GET"])
+@app.route("/change-password", methods=["GET", "POST"])
 @login_required
 def change_password():
-    # POST 처리는 Issue 9에서 구현 예정
+    user = current_user()
+
+    if request.method == "POST":
+        current_pw = request.form.get("currentPassword", "").strip()
+        new_pw     = request.form.get("newPassword",     "")
+        confirm_pw = request.form.get("confirmPassword", "")
+
+        # --- 빈 칸 검사 ---
+        if not current_pw:
+            return render_template(
+                "change_password.html",
+                active_page="profile",
+                error="Please enter your current password.",
+            )
+        if not new_pw:
+            return render_template(
+                "change_password.html",
+                active_page="profile",
+                error="Please enter a new password.",
+            )
+        if not confirm_pw:
+            return render_template(
+                "change_password.html",
+                active_page="profile",
+                error="Please confirm your new password.",
+            )
+
+        # --- 현재 비밀번호 검증 ---
+        if not check_password(current_pw, user.password_hash):
+            return render_template(
+                "change_password.html",
+                active_page="profile",
+                error="Current password is incorrect. Please try again.",
+            )
+
+        # --- 새 비밀번호 검증 ---
+        if len(new_pw) < 6:
+            return render_template(
+                "change_password.html",
+                active_page="profile",
+                error="New password must be at least 6 characters.",
+            )
+        if new_pw != confirm_pw:
+            return render_template(
+                "change_password.html",
+                active_page="profile",
+                error="New passwords do not match.",
+            )
+
+        # --- DB 업데이트 ---
+        user.password_hash = hash_password(new_pw)
+        db.session.commit()
+
+        return render_template(
+            "change_password.html",
+            active_page="profile",
+            success="Password updated successfully.",
+        )
+
     return render_template(
         "change_password.html",
         active_page="profile",

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 from flask import Flask, render_template, redirect, url_for, request, session, abort
 from functools import wraps
-from models import db, User
+from models import db, User, Follow
 from utils import hash_password, check_password
+from route_service import list_routes_for_author
 
 app = Flask(__name__)
 app.secret_key = "myvibe-dev-secret-change-in-production"
@@ -286,34 +287,47 @@ def change_password():
 def user_profile(username):
     """
     유저 공개 프로필 페이지.
-    실제 팔로우 여부 및 루트 조회는 Issue 11에서 구현 예정.
-    현재는 DB에서 유저 정보만 조회하고 나머지는 placeholder.
+    - 유저 정보, 공개 루트, 팔로워/팔로잉 수, 팔로우 여부를 DB에서 조회한다.
     """
     me = current_user()
 
-    # 존재하지 않는 유저 접근 시 404
+    # 존재하지 않는 유저 → 404
     profile_user = User.query.filter_by(username=username).first()
     if not profile_user:
         abort(404)
 
-    # 본인 프로필 접근 시 /profile 로 리다이렉트
+    # 본인 프로필 접근 → /profile 리다이렉트
     if me and me.id == profile_user.id:
         return redirect(url_for("profile"))
 
-    # -----------------------------------------------------------------------
-    # Issue 11에서 실제 DB 조회로 교체 예정
-    # -----------------------------------------------------------------------
-    is_own_profile  = False
-    is_following    = False
-    follower_count  = 0
-    following_count = 0
-    user_routes     = []
+    # -------------------------------------------------------------------
+    # 공개 루트 목록 조회 (route_service 활용, is_public=True 필터)
+    # -------------------------------------------------------------------
+    all_routes  = list_routes_for_author(profile_user.id)
+    user_routes = [r for r in all_routes if r.is_public]
+
+    # -------------------------------------------------------------------
+    # 팔로워 / 팔로잉 수 조회
+    # -------------------------------------------------------------------
+    follower_count  = Follow.query.filter_by(following_id=profile_user.id).count()
+    following_count = Follow.query.filter_by(follower_id=profile_user.id).count()
+
+    # -------------------------------------------------------------------
+    # 현재 유저의 팔로우 여부 확인
+    # -------------------------------------------------------------------
+    is_following = False
+    if me:
+        follow_record = Follow.query.filter_by(
+            follower_id  = me.id,
+            following_id = profile_user.id,
+        ).first()
+        is_following = follow_record is not None
 
     return render_template(
         "user_profile.html",
         active_page=None,
         profile_user=profile_user,
-        is_own_profile=is_own_profile,
+        is_own_profile=False,
         is_following=is_following,
         follower_count=follower_count,
         following_count=following_count,

--- a/static/js/pages/change-password.js
+++ b/static/js/pages/change-password.js
@@ -1,0 +1,165 @@
+/* global $, window */
+
+// Page: change_password.html
+// Features: empty field validation, real-time password match, loading state.
+(function changePasswordPage() {
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  function showInlineError(message) {
+    $("#changePasswordErrorText").text(message);
+    $("#changePasswordError").removeClass("hidden").addClass("flex");
+  }
+
+  function hideInlineError() {
+    $("#changePasswordError").removeClass("flex").addClass("hidden");
+    $("#changePasswordErrorText").text("");
+  }
+
+  function showFieldError($field, $errorEl) {
+    $field.addClass("border-rose-400 focus:border-rose-400");
+    $errorEl.removeClass("hidden");
+  }
+
+  function clearFieldError($field, $errorEl) {
+    $field.removeClass("border-rose-400 focus:border-rose-400");
+    $errorEl.addClass("hidden");
+  }
+
+  function setLoading(isLoading) {
+    const $btn = $("#changePasswordBtn");
+    if (isLoading) {
+      $btn
+        .prop("disabled", true)
+        .html(
+          `<span class="inline-flex items-center gap-2 justify-center">
+             <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+               <circle class="opacity-25" cx="12" cy="12" r="10"
+                 stroke="currentColor" stroke-width="4"></circle>
+               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
+             </svg>
+             Updating...
+           </span>`
+        );
+    } else {
+      $btn.prop("disabled", false).text("Update password");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Real-time password match indicator
+  // -------------------------------------------------------------------------
+
+  function updateMatchIndicator() {
+    const newPw  = String($("#newPassword").val()     || "");
+    const confirm = String($("#confirmPassword").val() || "");
+    const $msg   = $("#confirmPasswordMatchMsg");
+
+    if (!confirm) {
+      $msg.addClass("hidden").text("");
+      return;
+    }
+
+    if (newPw === confirm) {
+      $msg
+        .removeClass("hidden text-rose-600")
+        .addClass("text-emerald-600")
+        .text("✓ Passwords match");
+    } else {
+      $msg
+        .removeClass("hidden text-emerald-600")
+        .addClass("text-rose-600")
+        .text("✗ Passwords do not match");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  function validate() {
+    const current = String($("#currentPassword").val() || "").trim();
+    const newPw   = String($("#newPassword").val()     || "");
+    const confirm = String($("#confirmPassword").val() || "");
+    let valid = true;
+
+    // Current password
+    if (!current) {
+      showFieldError($("#currentPassword"), $("#currentPasswordError"));
+      valid = false;
+    } else {
+      clearFieldError($("#currentPassword"), $("#currentPasswordError"));
+    }
+
+    // New password length
+    if (newPw.length < 6) {
+      showFieldError($("#newPassword"), $("#newPasswordError"));
+      valid = false;
+    } else {
+      clearFieldError($("#newPassword"), $("#newPasswordError"));
+    }
+
+    // Confirm match
+    const $matchMsg = $("#confirmPasswordMatchMsg");
+    if (newPw !== confirm) {
+      $matchMsg
+        .removeClass("hidden text-emerald-600")
+        .addClass("text-rose-600")
+        .text("✗ Passwords do not match");
+      valid = false;
+    }
+
+    if (!valid) {
+      showInlineError("Please fix the errors above before continuing.");
+    } else {
+      hideInlineError();
+    }
+
+    return valid;
+  }
+
+  // -------------------------------------------------------------------------
+  // Mount
+  // -------------------------------------------------------------------------
+
+  function mountChangePassword() {
+    // 입력 시 해당 필드 에러 즉시 해제
+    $("#currentPassword").on("input", function () {
+      if (String($(this).val() || "").trim()) {
+        clearFieldError($(this), $("#currentPasswordError"));
+        hideInlineError();
+      }
+    });
+
+    $("#newPassword").on("input", function () {
+      if (String($(this).val() || "").length >= 6) {
+        clearFieldError($(this), $("#newPasswordError"));
+        hideInlineError();
+      }
+      updateMatchIndicator();
+    });
+
+    $("#confirmPassword").on("input", updateMatchIndicator);
+
+    // 폼 제출 처리
+    $("#changePasswordForm").on("submit", function (e) {
+      if (!validate()) {
+        e.preventDefault();
+        return;
+      }
+
+      setLoading(true);
+
+      // 서버 응답 지연 대비 5초 후 버튼 복구
+      window.setTimeout(function () {
+        setLoading(false);
+      }, 5000);
+    });
+  }
+
+  $(document).ready(function () {
+    if ($("body").attr("data-page") === "change-password") mountChangePassword();
+  });
+})();

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -48,48 +48,82 @@
         </div>
 
         <div class="mt-5 flex flex-wrap gap-2">
-          <button data-tab="my" class="tabBtn rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">My Routes</button>
-          <button data-tab="saved" class="tabBtn rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-50">Saved Routes</button>
-          <button data-tab="locations" class="tabBtn rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-50">My Locations</button>
-          <button data-tab="settings" class="tabBtn rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-50">Settings</button>
+          <button data-tab="my"
+            class="tabBtn rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">
+            My Routes
+          </button>
+          <button data-tab="saved"
+            class="tabBtn rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-50">
+            Saved Routes
+          </button>
+          <button data-tab="locations"
+            class="tabBtn rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-50">
+            My Locations
+          </button>
+          <button data-tab="settings"
+            class="tabBtn rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-50">
+            Settings
+          </button>
         </div>
       </div>
 
+      <!-- My Routes -->
       <section data-tab-panel="my" class="mt-4">
         <h2 class="text-lg font-semibold text-slate-900">My routes</h2>
         <div id="myRoutesGrid" class="mt-3 grid gap-3 sm:grid-cols-2"></div>
       </section>
 
+      <!-- Saved Routes -->
       <section data-tab-panel="saved" class="mt-4 hidden">
         <h2 class="text-lg font-semibold text-slate-900">Saved routes</h2>
         <div id="savedRoutesGrid" class="mt-3 grid gap-3 sm:grid-cols-2"></div>
       </section>
 
+      <!-- My Locations -->
       <section data-tab-panel="locations" class="mt-4 hidden">
         <h2 class="text-lg font-semibold text-slate-900">My locations</h2>
         <div id="myLocationsGrid" class="mt-3 grid gap-3 sm:grid-cols-2"></div>
       </section>
 
+      <!-- Settings -->
       <section data-tab-panel="settings" class="mt-4 hidden">
-        <h2 class="text-lg font-semibold text-slate-900">Settings (mock)</h2>
-        <div class="mt-3 rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
-          <div class="text-sm font-semibold text-slate-900">Change password (optional)</div>
-          <p class="mt-1 text-sm text-slate-600">Form only</p>
-          <div class="mt-4 grid gap-3 sm:grid-cols-3">
-            <input class="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none ring-sky-500/30 focus:ring-4" placeholder="Old password" type="password" />
-            <input class="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none ring-sky-500/30 focus:ring-4" placeholder="New password" type="password" />
-            <input class="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none ring-sky-500/30 focus:ring-4" placeholder="Confirm" type="password" />
+        <h2 class="text-lg font-semibold text-slate-900">Settings</h2>
+        <div class="mt-3 rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur space-y-6">
+
+          <!-- Change Password -->
+          <div>
+            <div class="text-sm font-semibold text-slate-900">Password</div>
+            <p class="mt-1 text-sm text-slate-600">
+              Update your password to keep your account secure.
+            </p>
+            
+              href="{{ url_for('change_password') }}"
+              class="mt-3 inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50"
+            >
+              Change password →
+            </a>
           </div>
-          <button type="button" class="mt-3 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50">
-            Save（mock）
-          </button>
-          <div class="mt-6 border-t border-slate-200 pt-4">
-            <button data-action="logout" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-800" type="button">
+
+          <div class="border-t border-slate-200"></div>
+
+          <!-- Logout -->
+          <div>
+            <div class="text-sm font-semibold text-slate-900">Session</div>
+            <p class="mt-1 text-sm text-slate-600">
+              Sign out from your current session.
+            </p>
+            <button
+              data-action="logout"
+              type="button"
+              class="mt-3 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-800"
+            >
               Logout
             </button>
           </div>
+
         </div>
       </section>
+
     </section>
   </section>
 </main>

--- a/templates/user_profile.html
+++ b/templates/user_profile.html
@@ -1,0 +1,184 @@
+{% extends "base.html" %}
+
+{% block title %}{{ profile_user.username }}'s Profile · MyVibe{% endblock %}
+{% block data_page %}user-profile{% endblock %}
+
+{% block content %}
+<main class="mx-auto w-[94vw] max-w-[1600px] px-6 py-10">
+  <section class="grid gap-6 lg:grid-cols-[360px,1fr]">
+
+    <!-- Left: profile card -->
+    <aside class="space-y-4">
+
+      <!-- Profile info -->
+      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-md backdrop-blur">
+        <div class="flex items-start gap-4">
+          <!-- Avatar initials -->
+          <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-slate-900 text-base font-semibold text-white">
+            {{ profile_user.username[0]|upper }}
+          </div>
+          <div class="min-w-0">
+            <div class="truncate text-lg font-semibold text-slate-900">
+              {{ profile_user.username }}
+            </div>
+            <div class="truncate text-sm font-semibold text-slate-600">
+              @{{ profile_user.username }}
+            </div>
+            <div class="mt-1 text-xs font-semibold text-slate-500">
+              Joined:
+              {% if profile_user.joined_at %}
+                {{ profile_user.joined_at.strftime('%b %Y') }}
+              {% else %}
+                —
+              {% endif %}
+            </div>
+          </div>
+        </div>
+
+        <!-- Bio -->
+        <div class="mt-5 rounded-2xl bg-slate-50 p-4">
+          <div class="text-xs font-semibold text-slate-600">Bio</div>
+          <div class="mt-2 text-sm leading-6 text-slate-700">
+            {{ profile_user.bio or 'No bio yet.' }}
+          </div>
+        </div>
+
+        <!-- Follow / Unfollow button -->
+        {% if not is_own_profile %}
+        <div class="mt-5">
+          <form method="POST" action="{{ url_for('follow_user', username=profile_user.username) }}">
+            {% if is_following %}
+            <button
+              id="followBtn"
+              type="submit"
+              class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-rose-50 hover:border-rose-200 hover:text-rose-700"
+            >
+              Unfollow
+            </button>
+            {% else %}
+            <button
+              id="followBtn"
+              type="submit"
+              class="w-full rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+            >
+              Follow
+            </button>
+            {% endif %}
+          </form>
+        </div>
+        {% endif %}
+
+        <!-- Back link -->
+        <div class="mt-4">
+          
+            href="{{ url_for('explore') }}"
+            class="text-sm font-semibold text-slate-500 hover:text-slate-900"
+          >
+            ← Back to Explore
+          </a>
+        </div>
+      </div>
+
+      <!-- Follower / Following counts -->
+      <div class="grid grid-cols-2 gap-3">
+        <div class="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm backdrop-blur text-center">
+          <div class="text-2xl font-semibold text-slate-900">
+            {{ follower_count }}
+          </div>
+          <div class="mt-1 text-xs font-semibold text-slate-600">Followers</div>
+        </div>
+        <div class="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm backdrop-blur text-center">
+          <div class="text-2xl font-semibold text-slate-900">
+            {{ following_count }}
+          </div>
+          <div class="mt-1 text-xs font-semibold text-slate-600">Following</div>
+        </div>
+      </div>
+
+    </aside>
+
+    <!-- Right: public routes -->
+    <section>
+      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
+              {{ profile_user.username }}'s routes
+            </h1>
+            <p class="mt-1 text-sm text-slate-600">
+              Public routes shared by this user
+            </p>
+          </div>
+          <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-600">
+            {{ user_routes | length }} route{{ 's' if user_routes | length != 1 else '' }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Route cards grid -->
+      <div class="mt-4 grid gap-3 sm:grid-cols-2">
+        {% for route in user_routes %}
+        
+          href="{{ url_for('route_detail', route_id=route.id) }}"
+          class="route-card block p-4 transition hover:-translate-y-0.5 hover:shadow-md"
+        >
+          <!-- Thumbnail placeholder -->
+          <div class="route-thumb flex items-center justify-center bg-gradient-to-br
+            {% if route.theme == 'first date' %}from-pink-100 to-rose-100
+            {% elif route.theme == 'picnic' %}from-yellow-100 to-amber-100
+            {% elif route.theme == 'active day' %}from-green-100 to-emerald-100
+            {% else %}from-violet-100 to-purple-100{% endif %}">
+            <span class="text-2xl">
+              {% if route.theme == 'first date' %}🌙
+              {% elif route.theme == 'picnic' %}☕
+              {% elif route.theme == 'active day' %}🎒
+              {% else %}🎨{% endif %}
+            </span>
+          </div>
+
+          <div class="mt-3">
+            <!-- Theme badge -->
+            <span class="rounded-full bg-slate-900 px-2 py-0.5 text-xs font-semibold text-white">
+              {{ route.theme }}
+            </span>
+
+            <!-- Title -->
+            <div class="mt-2 text-sm font-semibold text-slate-900 truncate">
+              {{ route.title }}
+            </div>
+
+            <!-- Meta -->
+            <div class="mt-1 text-xs text-slate-600">
+              {{ route.locations | length }} stop{{ 's' if route.locations | length != 1 else '' }}
+              · {{ route.created_at.strftime('%b %d, %Y') if route.created_at else '—' }}
+            </div>
+
+            <!-- Tags -->
+            {% if route.tags %}
+            <div class="mt-2 flex flex-wrap gap-1">
+              {% for tag in route.tags[:3] %}
+              <span class="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-600">
+                #{{ tag }}
+              </span>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </div>
+        </a>
+
+        {% else %}
+        <!-- Empty state -->
+        <div class="col-span-2 rounded-2xl border border-slate-200 bg-white/70 p-8 text-center shadow-sm backdrop-blur">
+          <div class="text-2xl">🗺️</div>
+          <div class="mt-2 text-sm font-semibold text-slate-700">No public routes yet.</div>
+          <div class="mt-1 text-xs text-slate-500">
+            This user hasn't shared any routes yet.
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+
+    </section>
+  </section>
+</main>
+{% endblock %}


### PR DESCRIPTION
## Overview
This PR replaces the placeholder `/user/<username>` route with a fully implemented backend that queries real user data, public routes, and follow state from the database.

## Changes
- Queried `profile_user` from the database by username (returns 404 if not found)
- Retrieved the user's public routes using `list_routes_for_author()` filtered by `is_public=True`
- Calculated follower and following counts using the Follow model
- Implemented follow state check between the current user and the profile user
- Passed all real values (`profile_user`, `user_routes`, `follower_count`, `following_count`, `is_following`) to the template
- Redirected to `/profile` when accessing own profile
- Ensured private routes are excluded from the public profile view

## Testing
- Verified `/user/<username>` displays correct profile data
- Verified public routes are shown in newest-first order
- Verified private routes are not displayed
- Verified follower and following counts are accurate
- Verified follow state reflects correctly
- Verified accessing own profile redirects to `/profile`
- Verified non-existent usernames return 404

Closes #65 