### PR TITLE
[Feature] Notifications page - HTML, backend, and read handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ db.init_app(app)
 # ---------------------------------------------------------------------------
 
 def seed_demo_users():
+    """Insert demo accounts on first run. Skips existing usernames."""
     demo_accounts = [
         {
             "username": "alex",
@@ -61,7 +62,7 @@ with app.app_context():
     seed_demo_users()
 
 # ---------------------------------------------------------------------------
-# Mock data
+# Static data
 # ---------------------------------------------------------------------------
 
 THEMES = ["first date", "picnic", "active day", "hidden gems"]
@@ -71,6 +72,7 @@ THEMES = ["first date", "picnic", "active day", "hidden gems"]
 # ---------------------------------------------------------------------------
 
 def current_user():
+    """Return the logged-in User object from session, or None."""
     user_id = session.get("user_id")
     if not user_id:
         return None
@@ -79,7 +81,22 @@ def current_user():
 
 @app.context_processor
 def inject_template_globals():
+    """
+    Inject shared variables into every template:
+    - current_user    : User object or None
+    - server_username : username string for legacy templates
+    - myvibe_bootstrap: auth state dict for JS
+    - unread_count    : unread notification count for nav badge
+    """
     user = current_user()
+
+    unread_count = 0
+    if user:
+        unread_count = Notification.query.filter_by(
+            recipient_id = user.id,
+            is_read      = False,
+        ).count()
+
     return {
         "current_user":    user,
         "server_username": user.username if user else None,
@@ -88,10 +105,12 @@ def inject_template_globals():
             "username":        user.username if user else None,
             "userId":          user.id if user else None,
         },
+        "unread_count": unread_count,
     }
 
 
 def login_required(f):
+    """Redirect unauthenticated requests to the login page."""
     @wraps(f)
     def decorated(*args, **kwargs):
         if session.get("user_id") is None:
@@ -100,7 +119,7 @@ def login_required(f):
     return decorated
 
 # ---------------------------------------------------------------------------
-# Routes
+# Auth routes
 # ---------------------------------------------------------------------------
 
 @app.route("/")
@@ -177,6 +196,9 @@ def logout():
     session.clear()
     return redirect(url_for("index"))
 
+# ---------------------------------------------------------------------------
+# Main page routes
+# ---------------------------------------------------------------------------
 
 @app.route("/dashboard")
 @login_required
@@ -231,6 +253,9 @@ def profile():
         following_count=following_count,
     )
 
+# ---------------------------------------------------------------------------
+# Change password
+# ---------------------------------------------------------------------------
 
 @app.route("/change-password", methods=["GET", "POST"])
 @login_required
@@ -283,16 +308,21 @@ def change_password():
 
     return render_template("change_password.html", active_page="profile")
 
+# ---------------------------------------------------------------------------
+# User public profile
+# ---------------------------------------------------------------------------
 
 @app.route("/user/<username>")
 @login_required
 def user_profile(username):
+    """Public profile page for any user. Redirects to /profile if viewing own page."""
     me = current_user()
 
     profile_user = User.query.filter_by(username=username).first()
     if not profile_user:
         abort(404)
 
+    # Redirect to own profile if the viewer is the same user
     if me and me.id == profile_user.id:
         return redirect(url_for("profile"))
 
@@ -315,13 +345,20 @@ def user_profile(username):
         is_following=is_following,
         follower_count=follower_count,
         following_count=following_count,
-        user_routes=[],  # route_service는 팀원 PR 머지 후 연결
+        user_routes=[],  # Connected after team PR route_service merge
     )
 
+# ---------------------------------------------------------------------------
+# Follow / Unfollow
+# ---------------------------------------------------------------------------
 
 @app.route("/follow/<username>", methods=["POST"])
 @login_required
 def follow_user(username):
+    """
+    Toggle follow state between the current user and the target user.
+    Returns JSON with updated is_following and follower_count.
+    """
     me = current_user()
     if me is None:
         return jsonify(ok=False, error="Not signed in."), 401
@@ -339,10 +376,12 @@ def follow_user(username):
     ).first()
 
     if existing:
+        # Unfollow — remove the Follow row
         db.session.delete(existing)
         db.session.commit()
         is_following = False
     else:
+        # Follow — create Follow row and a follow Notification
         new_follow = Follow(
             follower_id  = me.id,
             following_id = profile_user.id,
@@ -366,6 +405,81 @@ def follow_user(username):
         follower_count=follower_count,
     )
 
+# ---------------------------------------------------------------------------
+# Notifications
+# ---------------------------------------------------------------------------
+
+@app.route("/notifications")
+@login_required
+def notifications():
+    """List all notifications for the current user, newest first."""
+    user = current_user()
+
+    notifs = (
+        Notification.query
+        .filter_by(recipient_id=user.id)
+        .order_by(Notification.created_at.desc())
+        .all()
+    )
+
+    # Attach sender User objects for display
+    sender_ids = {n.sender_id for n in notifs if n.sender_id}
+    senders    = {u.id: u for u in User.query.filter(User.id.in_(sender_ids)).all()}
+
+    notifications_with_sender = [
+        {"notification": n, "sender": senders.get(n.sender_id)}
+        for n in notifs
+    ]
+
+    unread_count = sum(1 for n in notifs if not n.is_read)
+
+    return render_template(
+        "notifications.html",
+        active_page="notifications",
+        notifications_with_sender=notifications_with_sender,
+        unread_count=unread_count,
+    )
+
+
+@app.route("/notifications/read", methods=["POST"])
+@login_required
+def notification_read():
+    """Mark a single notification as read. Accepts JSON body: {notification_id: int}."""
+    user = current_user()
+    data = request.get_json(silent=True) or {}
+    notif_id = data.get("notification_id")
+
+    if not notif_id:
+        return jsonify(ok=False, error="notification_id is required."), 400
+
+    notif = Notification.query.filter_by(
+        id           = notif_id,
+        recipient_id = user.id,
+    ).first()
+
+    if not notif:
+        return jsonify(ok=False, error="Notification not found."), 404
+
+    notif.is_read = True
+    db.session.commit()
+
+    return jsonify(ok=True)
+
+
+@app.route("/notifications/read-all", methods=["POST"])
+@login_required
+def notification_read_all():
+    """Mark all notifications for the current user as read."""
+    user = current_user()
+
+    Notification.query.filter_by(
+        recipient_id = user.id,
+        is_read      = False,
+    ).update({"is_read": True})
+
+    db.session.commit()
+
+    return jsonify(ok=True)
 
 # ---------------------------------------------------------------------------
 # Legacy page redirects

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,17 +1,14 @@
 <!doctype html>
-<html lang="zh-Hans">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}MyVibe{% endblock %}</title>
-
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- jQuery -->
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
-
     {% block extra_head %}{% endblock %}
   </head>
   <body data-page="{% block data_page %}{% endblock %}" class="app-bg min-h-screen bg-slate-50 text-slate-900">
@@ -19,8 +16,11 @@
     {% block header %}
     <header class="app-header sticky top-0 z-40 bg-white/70 backdrop-blur">
       <div class="mx-auto flex w-[94vw] max-w-[1600px] items-center justify-between px-6 py-4">
+
+        <!-- Brand -->
         <a href="{{ url_for('index') }}" class="text-2xl brand-text">MyVibe</a>
 
+        <!-- Nav links -->
         <nav class="hidden items-center gap-1 sm:flex">
           <a href="{{ url_for('dashboard') }}"
              class="rounded-xl px-3 py-2 text-sm font-semibold {% if active_page == 'dashboard' %}bg-slate-900 text-white{% else %}text-slate-700 hover:bg-white hover:text-slate-900{% endif %}">
@@ -38,16 +38,31 @@
              class="rounded-xl px-3 py-2 text-sm font-semibold {% if active_page == 'profile' %}bg-slate-900 text-white{% else %}text-slate-700 hover:bg-white hover:text-slate-900{% endif %}">
             Profile
           </a>
+
+          <!-- Notification bell with unread badge -->
+          <a href="{{ url_for('notifications') }}"
+             class="relative rounded-xl px-3 py-2 text-sm font-semibold {% if active_page == 'notifications' %}bg-slate-900 text-white{% else %}text-slate-700 hover:bg-white hover:text-slate-900{% endif %}">
+            <!-- Bell icon -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="inline-block h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+            <!-- Unread count badge — hidden when count is 0 -->
+            {% if unread_count and unread_count > 0 %}
+            <span class="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-rose-500 text-[10px] font-bold text-white">
+              {{ unread_count if unread_count < 10 else '9+' }}
+            </span>
+            {% endif %}
+          </a>
         </nav>
 
+        <!-- Right: logout -->
         <div class="flex items-center gap-3">
-          <button
-            data-action="logout"
-            class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
-          >
+          <button data-action="logout"
+                  class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
             Logout
           </button>
         </div>
+
       </div>
     </header>
     {% endblock %}
@@ -55,29 +70,29 @@
     {% block content %}{% endblock %}
 
     {% block toast %}
-    <div
-      id="toast"
-      class="toast fixed bottom-6 left-1/2 z-50 w-[min(92vw,420px)] -translate-x-1/2 rounded-2xl px-4 py-3 text-sm font-medium text-white shadow-lg"
-    >
+    <div id="toast"
+         class="toast fixed bottom-6 left-1/2 z-50 w-[min(92vw,420px)] -translate-x-1/2 rounded-2xl px-4 py-3 text-sm font-medium text-white shadow-lg">
       <div class="flex items-center justify-between gap-3">
         <div data-toast-text>—</div>
-        <button
-          type="button"
-          class="rounded-xl bg-white/15 px-3 py-1 text-xs font-semibold text-white hover:bg-white/20"
-          onclick="document.getElementById('toast').classList.remove('is-visible')"
-        >
+        <button type="button"
+                class="rounded-xl bg-white/15 px-3 py-1 text-xs font-semibold text-white hover:bg-white/20"
+                onclick="document.getElementById('toast').classList.remove('is-visible')">
           Close
         </button>
       </div>
     </div>
     {% endblock %}
 
-    <script>
-      window.MYVIBE_BOOTSTRAP = {
-        isAuthenticated: {{ (server_username is not none)|tojson }},
-        username: {{ server_username|tojson }}
-      };
+    <!-- Bootstrap data for JS -->
+    <script id="myvibe-bootstrap-data" type="application/json">
+      {{- myvibe_bootstrap|tojson -}}
     </script>
+    <script>
+      window.MYVIBE_BOOTSTRAP = JSON.parse(
+        document.getElementById("myvibe-bootstrap-data").textContent
+      );
+    </script>
+
     <script src="{{ url_for('static', filename='js/interactions.js') }}"></script>
     {% block scripts %}{% endblock %}
   </body>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,0 +1,189 @@
+{% extends "base.html" %}
+
+{% block title %}Notifications · MyVibe{% endblock %}
+{% block data_page %}notifications{% endblock %}
+
+{% block content %}
+<main class="mx-auto w-[94vw] max-w-[1600px] px-6 py-10">
+
+  <!-- Page header -->
+  <section class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <div class="text-sm font-semibold text-slate-600">Activity</div>
+      <h1 class="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">Notifications</h1>
+      <p class="mt-2 text-sm text-slate-600">
+        {% if unread_count > 0 %}
+          You have <span class="font-semibold text-slate-900">{{ unread_count }}</span> unread notification{{ 's' if unread_count != 1 else '' }}.
+        {% else %}
+          You're all caught up.
+        {% endif %}
+      </p>
+    </div>
+
+    <!-- Mark all as read button -->
+    {% if notifications_with_sender %}
+    <button id="btnMarkAllRead"
+            type="button"
+            class="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50">
+      Mark all as read
+    </button>
+    {% endif %}
+  </section>
+
+  <!-- Notification list -->
+  <section class="mt-6">
+    {% if notifications_with_sender %}
+    <ul class="space-y-2">
+      {% for item in notifications_with_sender %}
+      {% set n = item.notification %}
+      {% set sender = item.sender %}
+
+      <li id="notif-{{ n.id }}"
+          class="rounded-2xl border shadow-sm transition
+                 {% if not n.is_read %}
+                   border-sky-200 bg-white
+                 {% else %}
+                   border-slate-200 bg-slate-50
+                 {% endif %}">
+        <div class="flex items-start gap-4 p-4">
+
+          <!-- Type icon -->
+          <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl
+                      {% if n.type == 'follow' %}bg-violet-100 text-violet-700
+                      {% elif n.type == 'like' %}bg-rose-100 text-rose-600
+                      {% elif n.type == 'comment' %}bg-sky-100 text-sky-700
+                      {% else %}bg-slate-100 text-slate-600{% endif %}">
+            {% if n.type == 'follow' %}
+              👤
+            {% elif n.type == 'like' %}
+              ❤️
+            {% elif n.type == 'comment' %}
+              💬
+            {% else %}
+              🔔
+            {% endif %}
+          </div>
+
+          <!-- Message -->
+          <div class="min-w-0 flex-1">
+            <p class="text-sm {% if not n.is_read %}font-semibold text-slate-900{% else %}text-slate-600{% endif %}">
+              {% if n.type == 'follow' %}
+                <span class="font-semibold">{{ sender.username if sender else 'Someone' }}</span>
+                started following you.
+              {% elif n.type == 'like' %}
+                <span class="font-semibold">{{ sender.username if sender else 'Someone' }}</span>
+                liked your route.
+              {% elif n.type == 'comment' %}
+                <span class="font-semibold">{{ sender.username if sender else 'Someone' }}</span>
+                commented on your route.
+              {% else %}
+                You have a new notification.
+              {% endif %}
+            </p>
+            <p class="mt-1 text-xs text-slate-500">
+              {{ n.created_at.strftime('%b %d, %Y · %H:%M') if n.created_at else '—' }}
+            </p>
+          </div>
+
+          <!-- Unread indicator dot -->
+          {% if not n.is_read %}
+          <div class="mt-1 h-2 w-2 shrink-0 rounded-full bg-sky-500"></div>
+          {% endif %}
+
+          <!-- Mark as read button (single) -->
+          {% if not n.is_read %}
+          <button type="button"
+                  data-notif-id="{{ n.id }}"
+                  class="btnMarkRead shrink-0 rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+            Mark read
+          </button>
+          {% endif %}
+
+        </div>
+
+        <!-- Left border accent for unread -->
+        {% if not n.is_read %}
+        <div class="absolute left-0 top-0 h-full w-1 rounded-l-2xl bg-sky-400"></div>
+        {% endif %}
+      </li>
+
+      {% endfor %}
+    </ul>
+
+    {% else %}
+    <!-- Empty state -->
+    <div class="rounded-3xl border border-slate-200 bg-white/70 p-12 text-center shadow-sm backdrop-blur">
+      <div class="text-4xl">🔔</div>
+      <div class="mt-4 text-base font-semibold text-slate-700">No notifications yet.</div>
+      <p class="mt-2 text-sm text-slate-500">
+        When someone follows you or interacts with your routes, it will show up here.
+      </p>
+      <a href="{{ url_for('explore') }}"
+         class="mt-6 inline-flex items-center justify-center rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-800">
+        Explore routes
+      </a>
+    </div>
+    {% endif %}
+  </section>
+
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  // Mark a single notification as read via AJAX
+  document.querySelectorAll(".btnMarkRead").forEach(function (btn) {
+    btn.addEventListener("click", async function () {
+      const notifId = parseInt(btn.getAttribute("data-notif-id"), 10);
+      try {
+        const res = await fetch("/notifications/read", {
+          method:      "POST",
+          credentials: "same-origin",
+          headers:     { "Content-Type": "application/json" },
+          body:        JSON.stringify({ notification_id: notifId }),
+        });
+        const data = await res.json();
+        if (data.ok) {
+          // Update the notification card style without a full reload
+          const card = document.getElementById("notif-" + notifId);
+          if (card) {
+            card.classList.remove("border-sky-200", "bg-white");
+            card.classList.add("border-slate-200", "bg-slate-50");
+            btn.remove();
+            const dot = card.querySelector(".bg-sky-500");
+            if (dot) dot.remove();
+            const text = card.querySelector("p");
+            if (text) {
+              text.classList.remove("font-semibold", "text-slate-900");
+              text.classList.add("text-slate-600");
+            }
+          }
+        }
+      } catch (err) {
+        console.error("Failed to mark notification as read:", err);
+      }
+    });
+  });
+
+  // Mark all notifications as read
+  const btnMarkAll = document.getElementById("btnMarkAllRead");
+  if (btnMarkAll) {
+    btnMarkAll.addEventListener("click", async function () {
+      try {
+        const res = await fetch("/notifications/read-all", {
+          method:      "POST",
+          credentials: "same-origin",
+          headers:     { "Content-Type": "application/json" },
+        });
+        const data = await res.json();
+        if (data.ok) {
+          // Reload the page to reflect all-read state
+          window.location.reload();
+        }
+      } catch (err) {
+        console.error("Failed to mark all notifications as read:", err);
+      }
+    });
+  }
+</script>
+{% endblock %}


### PR DESCRIPTION
## Overview
This PR implements the full notifications feature, including notification UI, backend routes, read handling, and a global unread badge in the navigation.

## Changes

### Notifications Page
- Created `notifications.html` extending `base.html`
- Added notification list UI with read/unread distinction
- Added per-type icons and messages (follow / like / comment)
- Added empty state handling
- Added "Mark all as read" button

### Backend
- Added GET `/notifications` route
- Added POST `/notifications/read` route
- Added POST `/notifications/read-all` route
- Queried notifications newest first
- Updated notifications as `is_read=True`
- Injected `unread_count` globally via `context_processor`

### Navigation Badge
- Added notification bell icon to navigation
- Added unread count badge
- Hid badge when unread_count is 0
- Linked badge to `/notifications`

## Testing
- Verified notifications display newest first
- Verified unread notifications use distinct styling
- Verified read notifications appear muted
- Verified notification messages render correctly by type
- Verified "Mark all as read" updates all notifications
- Verified nav badge updates correctly
- Verified empty state renders when there are no notifications

Closes #71 