### PR TITLE
[Core] Implement the Route detail: UX polish, duplicate-to-create flow, and client stability fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from models import db, User, Follow, Notification
 from route_service import (
     RouteValidationError,
     create_route_from_payload,
+    duplicate_route_for_user,
     get_route_for_viewer,
     list_routes_for_author,
     serialize_route_for_client,
@@ -408,6 +409,24 @@ def api_get_route(route_id):
     if route is None:
         return jsonify(ok=False, error="Not found."), 404
     return jsonify(ok=True, route=serialize_route_for_client(route))
+
+
+@app.route("/api/routes/<int:route_id>/duplicate", methods=["POST"])
+@login_required
+def api_duplicate_route(route_id):
+    user = current_user()
+    if user is None:
+        return jsonify(ok=False, error="Not signed in."), 401
+    source_route = get_route_for_viewer(route_id, user.id)
+    if source_route is None:
+        return jsonify(ok=False, error="Not found."), 404
+    try:
+        cloned = duplicate_route_for_user(route_id, user.id)
+    except Exception:
+        return jsonify(ok=False, error="Could not duplicate route. Try again."), 500
+    if cloned is None:
+        return jsonify(ok=False, error="Not found."), 404
+    return jsonify(ok=True, route=serialize_route_for_client(cloned)), 201
 
 
 @app.route("/api/my-routes", methods=["GET"])

--- a/route_service.py
+++ b/route_service.py
@@ -248,6 +248,51 @@ def list_routes_for_author(author_id: int) -> list[Route]:
     )
 
 
+def duplicate_route_for_user(source_route_id: int, new_author_id: int) -> Optional[Route]:
+    """
+    Clone a visible route into a new route owned by new_author_id.
+    Returns None when source route does not exist.
+    """
+    source = get_route_by_id(int(source_route_id))
+    if source is None:
+        return None
+
+    aid = _require_author_id(new_author_id)
+    _author_user(aid)
+
+    clone = Route(
+        author_id=aid,
+        title=source.title,
+        description=source.description,
+        theme=source.theme,
+        tags=list(source.tags or []),
+        is_public=bool(source.is_public),
+    )
+    db.session.add(clone)
+    db.session.flush()
+
+    for loc in sorted(source.locations, key=lambda x: x.stop_order):
+        db.session.add(
+            RouteLocation(
+                route_id=clone.id,
+                stop_order=loc.stop_order,
+                name=loc.name,
+                time=loc.time,
+                description=loc.description,
+                parking=loc.parking,
+                photo_url=loc.photo_url,
+                lat=loc.lat,
+                lng=loc.lng,
+            )
+        )
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    return clone
+
+
 def serialize_route_for_client(route: Route) -> dict[str, Any]:
     """
     One JSON-shaped dict for create response, detail, edit prefill, and listings.

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -6,9 +6,11 @@
   const C = window.AppCore;
   if (!C) return;
   const COMMENTS_KEY = "mv_route_comments_v1";
+  const CREATE_DRAFT_KEY = "mv_create_route_draft_v1";
 
   function commentsStore() {
-    return C.readStore(COMMENTS_KEY, {});
+    const store = C.readStore(COMMENTS_KEY, {});
+    return store && typeof store === "object" ? store : {};
   }
 
   function writeCommentsStore(store) {
@@ -18,7 +20,8 @@
   function routeComments(routeId) {
     const key = String(routeId || "");
     const store = commentsStore();
-    return Array.isArray(store[key]) ? store[key] : [];
+    const list = store[key];
+    return Array.isArray(list) ? list : [];
   }
 
   function saveRouteComments(routeId, comments) {
@@ -112,7 +115,7 @@
     const routes = C.readStore(C.STORAGE_KEYS.routes, []);
     const saved = C.readStore(C.STORAGE_KEYS.saved, []);
     const session = C.getSession();
-    const boot = global.MYVIBE_BOOTSTRAP || {};
+    const boot = window.MYVIBE_BOOTSTRAP || {};
 
     const pathParts = window.location.pathname.split("/").filter(Boolean);
     const pathRouteId = pathParts[0] === "route" ? decodeURIComponent(pathParts[1] || "") : "";
@@ -121,8 +124,8 @@
 
     let route = null;
     if (numericId) {
-      if (global.MYVIBE_ROUTE) {
-        route = { ...global.MYVIBE_ROUTE, id: String(global.MYVIBE_ROUTE.id) };
+      if (window.MYVIBE_ROUTE) {
+        route = { ...window.MYVIBE_ROUTE, id: String(window.MYVIBE_ROUTE.id) };
       } else {
         try {
           const data = await C.fetchJson(`api/routes/${encodeURIComponent(routeId)}`);
@@ -259,26 +262,39 @@
         C.showToast("Please sign in first.", "error");
         return;
       }
-      const nextRoutes = C.readStore(C.STORAGE_KEYS.routes, []);
-      const nextId = `r_${Math.floor(Math.random() * 1000000)}`;
-      const cloned = {
-        ...route,
-        id: nextId,
-        authorId: me.userId,
-        authorUsername: me.username,
-        title: route.title,
-        createdAt: C.nowIso(),
-        updatedAt: C.nowIso(),
-        locations: (route.locations || [])
-          .slice()
-          .sort((a, b) => a.order - b.order)
-          .map((loc, i) => ({ ...loc, order: i + 1 })),
+
+      const orderedLocations = (route.locations || [])
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .map((loc, i) => ({
+          order: i + 1,
+          name: String(loc.name || "").trim(),
+          time: String(loc.time || "").trim(),
+          desc: String(loc.desc || loc.description || "").trim(),
+          parking: String(loc.parking || "unknown").trim() || "unknown",
+          photoUrl: loc.photoUrl || null,
+        }));
+
+      const duplicateDraft = {
+        title: String(route.title || "").trim(),
+        theme: String(route.theme || "").trim(),
+        tags: (route.tags || []).join(", "),
+        description: String(route.description || "").trim(),
+        isPublic: Boolean(route.isPublic),
+        locations: orderedLocations,
+        savedAt: C.nowIso(),
       };
-      nextRoutes.push(cloned);
-      C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
-      C.showToast("Route duplicated. Opening edit mode…", "success");
+
+      try {
+        window.localStorage.setItem(CREATE_DRAFT_KEY, JSON.stringify(duplicateDraft));
+      } catch {
+        C.showToast("Could not prepare duplicate draft.", "error");
+        return;
+      }
+
+      C.showToast("Duplicate loaded. Opening create route…", "success");
       window.setTimeout(() => {
-        window.location.href = C.createRouteUrl(nextId, "edit");
+        window.location.href = C.appUrl("create-route");
       }, 350);
     });
 

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -5,6 +5,103 @@
 (function routePage() {
   const C = window.AppCore;
   if (!C) return;
+  const COMMENTS_KEY = "mv_route_comments_v1";
+
+  function commentsStore() {
+    return C.readStore(COMMENTS_KEY, {});
+  }
+
+  function writeCommentsStore(store) {
+    C.writeStore(COMMENTS_KEY, store);
+  }
+
+  function routeComments(routeId) {
+    const key = String(routeId || "");
+    const store = commentsStore();
+    return Array.isArray(store[key]) ? store[key] : [];
+  }
+
+  function saveRouteComments(routeId, comments) {
+    const key = String(routeId || "");
+    const store = commentsStore();
+    store[key] = comments;
+    writeCommentsStore(store);
+  }
+
+  function timeAgoLabel(iso) {
+    const ts = new Date(iso).getTime();
+    if (!Number.isFinite(ts)) return "just now";
+    const diffMin = Math.max(0, Math.floor((Date.now() - ts) / 60000));
+    if (diffMin < 1) return "just now";
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour}h ago`;
+    const diffDay = Math.floor(diffHour / 24);
+    return `${diffDay}d ago`;
+  }
+
+  function renderComments(routeId) {
+    const list = routeComments(routeId);
+    if (!list.length) {
+      $("#commentList").html(
+        `<div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">No comments yet. Be the first to comment.</div>`
+      );
+      return;
+    }
+    $("#commentList").html(
+      list
+        .slice()
+        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+        .map(
+          (c) => `
+        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
+          <div class="text-xs font-semibold text-slate-600">${C.escapeHtml(c.author)} · ${C.escapeHtml(timeAgoLabel(c.createdAt))}</div>
+          <div class="mt-2">${C.escapeHtml(c.text)}</div>
+        </div>
+      `
+        )
+        .join("")
+    );
+  }
+
+  function renderSimilarRoutes(route, routes) {
+    const currentTags = new Set((route.tags || []).map((t) => String(t || "").toLowerCase()));
+    const currentTheme = String(route.theme || "").toLowerCase();
+    const similar = routes
+      .filter((r) => String(r.id) !== String(route.id))
+      .map((r) => {
+        const rTags = (r.tags || []).map((t) => String(t || "").toLowerCase());
+        const overlap = rTags.filter((t) => currentTags.has(t)).length;
+        let score = 0;
+        if (String(r.theme || "").toLowerCase() === currentTheme && currentTheme) score += 2;
+        score += overlap;
+        return { route: r, score };
+      })
+      .filter((x) => x.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 4)
+      .map((x) => x.route);
+
+    if (!similar.length) {
+      $("#similarRoutes").html(
+        `<div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">No similar routes available yet.</div>`
+      );
+      return;
+    }
+    $("#similarRoutes").html(
+      similar
+        .map(
+          (r) => `
+        <a href="${C.routeDetailUrl(r.id)}" class="rounded-2xl border border-slate-200 bg-white p-4 text-sm shadow-sm hover:bg-slate-50">
+          <div class="text-xs font-semibold text-slate-600">${C.escapeHtml(r.theme || "—")}</div>
+          <div class="mt-1 font-semibold text-slate-900">${C.escapeHtml(r.title || "Untitled route")}</div>
+          <div class="mt-2 text-slate-600">${C.escapeHtml((r.tags || []).slice(0, 3).map((t) => `#${t}`).join(" "))}</div>
+        </a>
+      `
+        )
+        .join("")
+    );
+  }
 
   async function mountRoute() {
     C.requireAuthOrRedirect();
@@ -47,10 +144,15 @@
     }
 
     const author = users.find((u) => u.id === route.authorId);
-    const authorLabel = route.authorUsername || (author ? author.name : "Unknown");
+    const authorLabel = route.authorUsername || (author ? author.username || author.name : "Unknown");
     $("#routeTitle").text(route.title);
     $("#routeTheme").text(route.theme);
     $("#routeAuthor").text(authorLabel);
+    if (authorLabel && authorLabel !== "Unknown") {
+      $("#routeAuthorLink").attr("href", C.appUrl(`user/${encodeURIComponent(String(authorLabel).toLowerCase())}`));
+    } else {
+      $("#routeAuthorLink").attr("href", "#");
+    }
     const createdLabel = route.createdAt ? C.formatDate(route.createdAt) : "—";
     $("#routeMeta").text(`${createdLabel} · ${route.locations.length} stops · ★ ${route.rating ?? 4}`);
     $("#routeDesc").text(route.description);
@@ -83,6 +185,8 @@
       })
       .join("");
     $("#routeLocations").html(locHtml);
+    renderSimilarRoutes(route, routes);
+    renderComments(route.id);
 
     const savedSet = new Set(saved || []);
     C.updateRouteButtons(route, savedSet);
@@ -131,7 +235,63 @@
       }
     });
 
-    $("#btnCmt").on("click", () => C.showToast("Comment section is placeholder only.", "info"));
+    $("#btnCmt").on("click", () => {
+      const text = String($("#cmt").val() || "").trim();
+      if (!text) {
+        C.showToast("Please enter a comment.", "error");
+        return;
+      }
+      const next = routeComments(route.id);
+      next.push({
+        author: boot.username || session?.username || "you",
+        text,
+        createdAt: C.nowIso(),
+      });
+      saveRouteComments(route.id, next);
+      $("#cmt").val("");
+      renderComments(route.id);
+      C.showToast("Comment added.", "success");
+    });
+
+    $("#btnDuplicate").on("click", () => {
+      const me = session || C.getSession();
+      if (!me) {
+        C.showToast("Please sign in first.", "error");
+        return;
+      }
+      const nextRoutes = C.readStore(C.STORAGE_KEYS.routes, []);
+      const nextId = `r_${Math.floor(Math.random() * 1000000)}`;
+      const cloned = {
+        ...route,
+        id: nextId,
+        authorId: me.userId,
+        authorUsername: me.username,
+        title: `${route.title} (copy)`,
+        createdAt: C.nowIso(),
+        updatedAt: C.nowIso(),
+        locations: (route.locations || [])
+          .slice()
+          .sort((a, b) => a.order - b.order)
+          .map((loc, i) => ({ ...loc, order: i + 1 })),
+      };
+      nextRoutes.push(cloned);
+      C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
+      C.showToast("Route duplicated to your account.", "success");
+      window.setTimeout(() => {
+        window.location.href = C.routeDetailUrl(nextId);
+      }, 350);
+    });
+
+    $("#btnCompleted").on("click", () => C.showToast("Marked as completed.", "success"));
+    $("#btnSubmitRating").on("click", () => {
+      const rating = String($("#ratingSelect").val() || "").trim();
+      if (!rating) {
+        C.showToast("Please choose a rating first.", "error");
+        return;
+      }
+      C.showToast(`Rating submitted: ${rating}/5.`, "success");
+    });
+    $("#btnReport").on("click", () => C.showToast("Report submitted. Thanks for your feedback.", "success"));
 
     $("#btnDeleteRoute").on("click", () => {
       if (!isOwner) return;

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -253,7 +253,7 @@
       C.showToast("Comment added.", "success");
     });
 
-    $("#btnDuplicate").on("click", () => {
+    $("#btnDuplicate").on("click", async () => {
       const me = session || C.getSession();
       if (!me) {
         C.showToast("Please sign in first.", "error");
@@ -266,7 +266,7 @@
         id: nextId,
         authorId: me.userId,
         authorUsername: me.username,
-        title: `${route.title} (copy)`,
+        title: route.title,
         createdAt: C.nowIso(),
         updatedAt: C.nowIso(),
         locations: (route.locations || [])
@@ -276,9 +276,9 @@
       };
       nextRoutes.push(cloned);
       C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
-      C.showToast("Route duplicated to your account.", "success");
+      C.showToast("Route duplicated. Opening edit mode…", "success");
       window.setTimeout(() => {
-        window.location.href = C.routeDetailUrl(nextId);
+        window.location.href = C.createRouteUrl(nextId, "edit");
       }, 350);
     });
 

--- a/templates/route.html
+++ b/templates/route.html
@@ -16,7 +16,7 @@
           <span id="routeTheme" class="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white">
             {{ route.theme if route else '—' }}
           </span>
-          <span>by <span id="routeAuthor" class="font-semibold text-slate-800">{{ route.author if route else '—' }}</span></span>
+          <span>by <a id="routeAuthorLink" href="#" class="font-semibold text-slate-800 hover:text-sky-800"><span id="routeAuthor">{{ route.author if route else '—' }}</span></a></span>
           <span class="text-slate-400">·</span>
           <span id="routeMeta">{{ route.meta if route else '—' }}</span>
         </div>
@@ -29,6 +29,7 @@
         <button id="btnLike" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50" type="button">❤ Like</button>
         <button id="btnSave" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50" type="button">🔖 Save</button>
         <button id="btnShare" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-800" type="button">Share</button>
+        <button id="btnDuplicate" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50" type="button">Duplicate</button>
       </div>
     </div>
 
@@ -69,33 +70,41 @@
     </section>
 
     <aside class="rounded-3xl border border-slate-200 bg-white/70 p-5 shadow-sm backdrop-blur">
-      <div class="text-sm font-semibold text-slate-900">Comments (optional)</div>
-      <p class="mt-1 text-sm text-slate-600">Simple placeholder section</p>
-
-      <div class="mt-4 space-y-3">
-        {% for comment in comments %}
-        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-          <div class="text-xs font-semibold text-slate-600">{{ comment.author }} · {{ comment.time }}</div>
-          <div class="mt-2">{{ comment.text }}</div>
+      <div class="rounded-2xl border border-slate-200 bg-white p-4">
+        <div class="text-xs font-semibold uppercase tracking-wide text-slate-600">Route actions</div>
+        <div class="mt-3 grid gap-2">
+          <button id="btnCompleted" type="button" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50">
+            Mark as completed
+          </button>
+          <div class="flex items-center gap-2">
+            <label for="ratingSelect" class="text-sm font-semibold text-slate-700">Rate</label>
+            <select id="ratingSelect" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-900">
+              <option value="">Select</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+            </select>
+            <button id="btnSubmitRating" type="button" class="rounded-lg border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-900 hover:bg-slate-50">Submit</button>
+          </div>
+          <button id="btnReport" type="button" class="rounded-xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 shadow-sm hover:bg-rose-100">
+            Report
+          </button>
         </div>
-        {% else %}
-        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-          <div class="text-xs font-semibold text-slate-600">mina · 2h ago</div>
-          <div class="mt-2">This route is perfect for weekends!</div>
-        </div>
-        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-          <div class="text-xs font-semibold text-slate-600">alex · 1h ago</div>
-          <div class="mt-2">Could add one more sunset spot.</div>
-        </div>
-        {% endfor %}
       </div>
+
+      <div class="text-sm font-semibold text-slate-900">Comments</div>
+      <p class="mt-1 text-sm text-slate-600">Leave a comment</p>
+
+      <div class="mt-4 space-y-3" id="commentList"></div>
 
       <div class="mt-4">
         <label class="text-sm font-medium text-slate-700" for="cmt">Add comment</label>
         <textarea
           id="cmt"
           class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none ring-sky-500/30 focus:ring-4"
-          placeholder="Mock input only (no submit logic)"
+          placeholder="Write your comment"
           rows="3"
         ></textarea>
         <button id="btnCmt" type="button"
@@ -104,6 +113,12 @@
         </button>
       </div>
     </aside>
+  </section>
+
+  <section class="mt-6 rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
+    <h2 class="text-lg font-semibold text-slate-900">Similar routes</h2>
+    <p class="mt-1 text-sm text-slate-600">Based on theme and tags</p>
+    <div id="similarRoutes" class="mt-4 grid gap-3 md:grid-cols-2"></div>
   </section>
 </main>
 {% endblock %}


### PR DESCRIPTION
**Goal**

Improve the route detail experience so users can view full route metadata and ordered stops, interact with owner actions and basic controls, duplicate a route into a pre-filled create flow that persists a **new** DB route on submit, and fix client-side errors that blocked the page and Duplicate from working reliably.


**Changes**

- **Route detail** renders title, theme, description, tags, and ordered stops (time, parking, descriptions, optional photos); author block uses server `authorUsername` when available; author links to `/user/<username>`.
- **Owner actions**: edit/delete strip remains owner-only via template `is_owner` + JS bootstrap `userId`; numeric-route edit/delete still delegated to placeholder toasts until update/delete APIs exist.
- **Duplicate**: writes a draft into `mv_create_route_draft_v1` and navigates to **Create route** (not edit); user edits and **Save route** triggers `POST /api/routes` so the copy gets a **new** `route_id` and **session author_id**, independent of the source route **(no `(copy)` title suffix)**.
- **Backend**: `POST /api/routes/<id>/duplicate` and `duplicate_route_for_user` remain available for cloning in DB without changing titles; frontend duplicate path favors draft + create per product ask.
- **Stability**: `route.js` uses `window.MYVIBE_BOOTSTRAP` / `window.MYVIBE_ROUTE` instead of undefined `global`; comment storage hardened so invalid `mv_route_comments_v1` (`null`/non-object) no longer crashes `mountRoute` (restores Duplicate and other bindings).
- **Still mock/local**: likes, save, comments, completed/rating/report toasts, and similar-route suggestions driven by existing local/mock patterns unless matching APIs are added later.

**Acceptance Criterion**:
- Route detail shows title, theme, description, tags, ordered locations 
- Duplicate opens pre-filled Create; submit creates new owned route without mutating original 
- Page loads without comment-cache crash blocking interactions
- Author profile link and owner-only chrome aligned with bootstrap when present 

**Need to polish**
- **Edit/delete numeric routes**: `PUT/PATCH` + `DELETE` on `/api/routes/<id>`, wire create-route edit and owner delete.
- **Real persistence** for saves, likes, comments, ratings if product wants server truth on detail/profile.

Closes #38 