### PR TITLE
[Feature] Add route cover upload, edit, and remove functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from route_service import (
     delete_route_for_owner,
     duplicate_route_for_user,
     get_route_for_viewer,
+    list_public_routes,
     list_routes_for_author,
     serialize_route_for_client,
     update_route_for_owner,
@@ -482,6 +483,17 @@ def api_list_my_routes():
     if user is None:
         return jsonify(ok=False, error="Not signed in."), 401
     routes = list_routes_for_author(user.id)
+    return jsonify(ok=True, routes=[serialize_route_for_client(route) for route in routes])
+
+
+@app.route("/api/routes/public", methods=["GET"])
+@login_required
+def api_list_public_routes():
+    """All public routes for home/explore-style listings (newest first, capped)."""
+    user = current_user()
+    if user is None:
+        return jsonify(ok=False, error="Not signed in."), 401
+    routes = list_public_routes()
     return jsonify(ok=True, routes=[serialize_route_for_client(route) for route in routes])
 
 

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import secrets
 
 from flask import Flask, abort, jsonify, redirect, render_template, request, session, url_for
 from functools import wraps
+from sqlalchemy import text
 from werkzeug.utils import secure_filename
 
 from models import db, User, Follow, Notification
@@ -18,11 +19,6 @@ from route_service import (
     serialize_route_for_client,
     update_route_for_owner,
 )
-from utils import check_password, hash_password
-from flask import Flask, render_template, redirect, url_for, request, session, abort
-from functools import wraps
-
-from models import db, User, Follow, Notification
 from utils import check_password, hash_password
 
 app = Flask(__name__)
@@ -78,8 +74,24 @@ def seed_demo_users():
     db.session.commit()
 
 
+def ensure_route_cover_photo_url_column():
+    """SQLite: add routes.cover_photo_url if missing (db.create_all does not ALTER)."""
+    try:
+        if db.engine.dialect.name != "sqlite":
+            return
+        rows = db.session.execute(text("PRAGMA table_info(routes)")).fetchall()
+        col_names = {row[1] for row in rows}
+        if "cover_photo_url" in col_names:
+            return
+        db.session.execute(text("ALTER TABLE routes ADD COLUMN cover_photo_url VARCHAR(500)"))
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+
+
 with app.app_context():
     db.create_all()
+    ensure_route_cover_photo_url_column()
     seed_demo_users()
 
 # ---------------------------------------------------------------------------

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from models import db, User, Follow, Notification
 from route_service import (
     RouteValidationError,
     create_route_from_payload,
+    duplicate_route_for_user,
     get_route_for_viewer,
     list_routes_for_author,
     serialize_route_for_client,
@@ -408,6 +409,24 @@ def api_get_route(route_id):
     if route is None:
         return jsonify(ok=False, error="Not found."), 404
     return jsonify(ok=True, route=serialize_route_for_client(route))
+
+
+@app.route("/api/routes/<int:route_id>/duplicate", methods=["POST"])
+@login_required
+def api_duplicate_route(route_id):
+    user = current_user()
+    if user is None:
+        return jsonify(ok=False, error="Not signed in."), 401
+    source_route = get_route_for_viewer(route_id, user.id)
+    if source_route is None:
+        return jsonify(ok=False, error="Not found."), 404
+    try:
+        cloned = duplicate_route_for_user(route_id, user.id)
+    except Exception:
+        return jsonify(ok=False, error="Could not duplicate route. Try again."), 500
+    if cloned is None:
+        return jsonify(ok=False, error="Not found."), 404
+    return jsonify(ok=True, route=serialize_route_for_client(cloned)), 201
 
 
 @app.route("/api/my-routes", methods=["GET"])

--- a/app.py
+++ b/app.py
@@ -18,6 +18,11 @@ from route_service import (
     update_route_for_owner,
 )
 from utils import check_password, hash_password
+from flask import Flask, render_template, redirect, url_for, request, session, abort
+from functools import wraps
+
+from models import db, User, Follow, Notification
+from utils import check_password, hash_password
 
 app = Flask(__name__)
 app.secret_key = "myvibe-dev-secret-change-in-production"

--- a/app.py
+++ b/app.py
@@ -7,18 +7,16 @@ from werkzeug.utils import secure_filename
 
 from models import db, User, Follow, Notification
 from route_service import (
+    RouteOwnershipError,
     RouteValidationError,
     create_route_from_payload,
+    delete_route_for_owner,
     duplicate_route_for_user,
     get_route_for_viewer,
     list_routes_for_author,
     serialize_route_for_client,
+    update_route_for_owner,
 )
-from utils import check_password, hash_password
-from flask import Flask, render_template, redirect, url_for, request, session, abort
-from functools import wraps
-
-from models import db, User, Follow, Notification
 from utils import check_password, hash_password
 
 app = Flask(__name__)
@@ -409,6 +407,49 @@ def api_get_route(route_id):
     if route is None:
         return jsonify(ok=False, error="Not found."), 404
     return jsonify(ok=True, route=serialize_route_for_client(route))
+
+
+@app.route("/api/routes/<int:route_id>", methods=["PATCH", "PUT"])
+@login_required
+def api_update_route(route_id):
+    """Full replace of route fields and ordered locations; author only."""
+    user = current_user()
+    if user is None:
+        return jsonify(ok=False, errors={"": "Not signed in."}), 401
+    if not request.is_json:
+        return jsonify(ok=False, errors={"": "Send JSON (Content-Type: application/json)."}), 400
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return jsonify(ok=False, errors={"": "Invalid JSON body."}), 400
+    try:
+        route = update_route_for_owner(route_id, user.id, body)
+    except ValueError:
+        return jsonify(ok=False, error="Not found."), 404
+    except RouteOwnershipError:
+        return jsonify(ok=False, error="Forbidden."), 403
+    except RouteValidationError as exc:
+        return jsonify(ok=False, errors=exc.errors), 400
+    except Exception:
+        return jsonify(ok=False, errors={"": "Could not update route. Try again."}), 500
+    return jsonify(ok=True, route=serialize_route_for_client(route))
+
+
+@app.route("/api/routes/<int:route_id>", methods=["DELETE"])
+@login_required
+def api_delete_route(route_id):
+    """Remove route and stops; author only."""
+    user = current_user()
+    if user is None:
+        return jsonify(ok=False, error="Not signed in."), 401
+    try:
+        deleted = delete_route_for_owner(route_id, user.id)
+    except RouteOwnershipError:
+        return jsonify(ok=False, error="Forbidden."), 403
+    except Exception:
+        return jsonify(ok=False, error="Could not delete route. Try again."), 500
+    if not deleted:
+        return jsonify(ok=False, error="Not found."), 404
+    return jsonify(ok=True)
 
 
 @app.route("/api/routes/<int:route_id>/duplicate", methods=["POST"])

--- a/models.py
+++ b/models.py
@@ -100,6 +100,8 @@ class Route(db.Model):
     # List of tag strings (same shape as front-end tags array).
     tags = db.Column(db.JSON, nullable=False, default=list)
     is_public = db.Column(db.Boolean, nullable=False, default=True)
+    # Optional hero image for cards / detail; same upload pipeline as stop photos.
+    cover_photo_url = db.Column(db.String(500), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/route_service.py
+++ b/route_service.py
@@ -248,6 +248,17 @@ def list_routes_for_author(author_id: int) -> list[Route]:
     )
 
 
+def list_public_routes(limit: int = 500) -> list[Route]:
+    """Dashboard / explore: all public routes, newest first (bounded for safety)."""
+    lim = max(1, min(int(limit), 2000))
+    return (
+        Route.query.filter_by(is_public=True)
+        .order_by(Route.created_at.desc())
+        .limit(lim)
+        .all()
+    )
+
+
 def duplicate_route_for_user(source_route_id: int, new_author_id: int) -> Optional[Route]:
     """
     Clone a visible route into a new route owned by new_author_id.

--- a/route_service.py
+++ b/route_service.py
@@ -53,7 +53,8 @@ def _prepare_create_route_data(
     author_id: Optional[int], payload: dict[str, Any]
 ) -> tuple[dict[str, str], Optional[tuple[int, str, str, str, list[str], bool, list[dict[str, Any]]]]]:
     """
-    Validate payload for create. Returns (errors, None) or ({}, (aid, title, description, theme, tags, is_public, validated_stops)).
+    Validate payload for create/update.
+    Returns (errors, None) or ({}, (aid, title, description, theme, tags, is_public, cover_photo_url, validated_stops)).
     """
     errors: dict[str, str] = {}
     try:
@@ -166,7 +167,16 @@ def _prepare_create_route_data(
             }
         )
 
-    return {}, (aid, title, description, theme, tags, is_public, validated_stops)
+    cover_raw = payload.get("photoUrl")
+    cover_photo_url = None
+    if cover_raw is not None:
+        s = str(cover_raw).strip()
+        if s:
+            if len(s) > 500:
+                return {"photoUrl": "Cover image URL is too long."}, None
+            cover_photo_url = s
+
+    return {}, (aid, title, description, theme, tags, is_public, cover_photo_url, validated_stops)
 
 
 def create_route_from_payload(author_id: Optional[int], payload: dict[str, Any]) -> Route:
@@ -174,7 +184,7 @@ def create_route_from_payload(author_id: Optional[int], payload: dict[str, Any])
     Insert a Route and its RouteLocation rows in one transaction.
 
     Payload keys align with the create-route form / localStorage mock:
-      title, description, theme, tags (list[str]), isPublic (bool), locations (list)
+      title, description, theme, tags (list[str]), isPublic (bool), photoUrl (optional route cover), locations (list)
     Each location: order, name, time, desc, parking; optional photoUrl, lat, lng.
     """
     prep = _prepare_create_route_data(author_id, payload)
@@ -182,7 +192,7 @@ def create_route_from_payload(author_id: Optional[int], payload: dict[str, Any])
     if errors or data is None:
         raise RouteValidationError(errors or {"": "Validation failed."})
 
-    aid, title, description, theme, tags, is_public, validated_stops = data
+    aid, title, description, theme, tags, is_public, cover_photo_url, validated_stops = data
 
     route = Route(
         author_id=aid,
@@ -191,6 +201,7 @@ def create_route_from_payload(author_id: Optional[int], payload: dict[str, Any])
         theme=theme,
         tags=tags,
         is_public=is_public,
+        cover_photo_url=cover_photo_url,
     )
     db.session.add(route)
     db.session.flush()
@@ -278,6 +289,7 @@ def duplicate_route_for_user(source_route_id: int, new_author_id: int) -> Option
         theme=source.theme,
         tags=list(source.tags or []),
         is_public=bool(source.is_public),
+        cover_photo_url=getattr(source, "cover_photo_url", None),
     )
     db.session.add(clone)
     db.session.flush()
@@ -328,13 +340,14 @@ def update_route_for_owner(route_id: int, owner_id: int, payload: dict[str, Any]
     if errors or data is None:
         raise RouteValidationError(errors or {"": "Validation failed."})
 
-    _aid, title, description, theme, tags, is_public, validated_stops = data
+    _aid, title, description, theme, tags, is_public, cover_photo_url, validated_stops = data
 
     route.title = title
     route.description = description
     route.theme = theme
     route.tags = tags
     route.is_public = is_public
+    route.cover_photo_url = cover_photo_url
 
     # Replace stops so UI order matches persisted stop_order exactly.
     route.locations.clear()
@@ -403,6 +416,7 @@ def serialize_route_for_client(route: Route) -> dict[str, Any]:
         "theme": route.theme,
         "tags": list(route.tags or []),
         "isPublic": bool(route.is_public),
+        "photoUrl": getattr(route, "cover_photo_url", None) or None,
         "createdAt": _iso_utc_z(route.created_at),
         "updatedAt": _iso_utc_z(route.updated_at),
         "likes": 0,

--- a/route_service.py
+++ b/route_service.py
@@ -248,6 +248,51 @@ def list_routes_for_author(author_id: int) -> list[Route]:
     )
 
 
+def duplicate_route_for_user(source_route_id: int, new_author_id: int) -> Optional[Route]:
+    """
+    Clone a visible route into a new route owned by new_author_id.
+    Returns None when source route does not exist.
+    """
+    source = get_route_by_id(int(source_route_id))
+    if source is None:
+        return None
+
+    aid = _require_author_id(new_author_id)
+    _author_user(aid)
+
+    clone = Route(
+        author_id=aid,
+        title=source.title,
+        description=source.description,
+        theme=source.theme,
+        tags=list(source.tags or []),
+        is_public=bool(source.is_public),
+    )
+    db.session.add(clone)
+    db.session.flush()
+
+    for loc in sorted(source.locations, key=lambda x: x.stop_order):
+        db.session.add(
+            RouteLocation(
+                route_id=clone.id,
+                stop_order=loc.stop_order,
+                name=loc.name,
+                time=loc.time,
+                description=loc.description,
+                parking=loc.parking,
+                photo_url=loc.photo_url,
+                lat=loc.lat,
+                lng=loc.lng,
+            )
+        )
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    return clone
+
+
 def serialize_route_for_client(route: Route) -> dict[str, Any]:
     """
     One JSON-shaped dict for create response, detail, edit prefill, and listings.

--- a/route_service.py
+++ b/route_service.py
@@ -293,6 +293,85 @@ def duplicate_route_for_user(source_route_id: int, new_author_id: int) -> Option
     return clone
 
 
+class RouteOwnershipError(Exception):
+    """Raised when a mutation targets a route the user does not own."""
+
+    pass
+
+
+def update_route_for_owner(route_id: int, owner_id: int, payload: dict[str, Any]) -> Route:
+    """
+    Replace route metadata and ordered stops for an existing route.
+
+    Raises RouteOwnershipError if the route exists but owner_id is not the author.
+    Raises RouteValidationError on invalid payload.
+    """
+    route = get_route_by_id(int(route_id))
+    if route is None:
+        raise ValueError("Route not found.")
+    if int(route.author_id) != int(owner_id):
+        raise RouteOwnershipError("Not allowed to edit this route.")
+
+    prep = _prepare_create_route_data(int(owner_id), payload)
+    errors, data = prep
+    if errors or data is None:
+        raise RouteValidationError(errors or {"": "Validation failed."})
+
+    _aid, title, description, theme, tags, is_public, validated_stops = data
+
+    route.title = title
+    route.description = description
+    route.theme = theme
+    route.tags = tags
+    route.is_public = is_public
+
+    # Replace stops so UI order matches persisted stop_order exactly.
+    route.locations.clear()
+    db.session.flush()
+
+    for row in validated_stops:
+        db.session.add(
+            RouteLocation(
+                route_id=route.id,
+                stop_order=row["stop_order"],
+                name=row["name"],
+                time=row["time"],
+                description=row["description"],
+                parking=row["parking"],
+                photo_url=row["photo_url"],
+                lat=row["lat"],
+                lng=row["lng"],
+            )
+        )
+
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    return route
+
+
+def delete_route_for_owner(route_id: int, owner_id: int) -> bool:
+    """
+    Permanently remove a route and its stops. Returns True when deleted.
+
+    Raises RouteOwnershipError if the route exists but owner_id is not the author.
+    """
+    route = get_route_by_id(int(route_id))
+    if route is None:
+        return False
+    if int(route.author_id) != int(owner_id):
+        raise RouteOwnershipError("Not allowed to delete this route.")
+    try:
+        db.session.delete(route)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    return True
+
+
 def serialize_route_for_client(route: Route) -> dict[str, Any]:
     """
     One JSON-shaped dict for create response, detail, edit prefill, and listings.

--- a/static/js/interactions.js
+++ b/static/js/interactions.js
@@ -378,7 +378,24 @@
 
   // Shared route card renderer for dashboard/explore/profile pages.
   function routeCardHtml(route, users, savedIds, options = {}) {
-    const author = users.find((u) => u.id === route.authorId);
+    const uid = route.authorId;
+    let author =
+      (Array.isArray(users) ? users : []).find((u) => u.id === uid) ||
+      (Array.isArray(users) ? users : []).find((u) => String(u.id) === String(uid));
+    if (!author && route.authorUsername) {
+      const uname = String(route.authorUsername).trim().toLowerCase();
+      author = (Array.isArray(users) ? users : []).find(
+        (u) => String(u.username || "").toLowerCase() === uname
+      );
+    }
+    const authorLabel =
+      (author && author.name) ||
+      String(route.authorUsername || "")
+        .trim()
+        .replace(/^@/, "") ||
+      "Unknown";
+    const initialsSource = author && author.name ? author.name : authorLabel;
+    const avatarTone = userAvatarTone(author || { username: authorLabel });
     const savedSet = new Set(savedIds || []);
     const saved = savedSet.has(route.id);
     const likedIds = new Set(readStore("mv_liked_route_ids", []));
@@ -386,7 +403,6 @@
     const themeKey = normalizeTheme(route.theme);
     const visual = themeVisual(themeKey);
     const badge = routeBadge(route);
-    const avatarTone = userAvatarTone(author);
     const stops = Number(route.locations?.length || 0);
     const showPhotoCover = Boolean(options.showPhotoCover);
     const tags = (route.tags || []).slice(0, 3);
@@ -417,9 +433,9 @@
         <div class="mt-3 flex items-center justify-between gap-2">
           <div class="flex min-w-0 items-center gap-2">
             <div class="flex h-[22px] w-[22px] items-center justify-center rounded-full text-[10px] font-medium" style="background:${avatarTone.bg};color:${avatarTone.text};">
-              ${escapeHtml(initials(author ? author.name : "Unknown"))}
+              ${escapeHtml(initials(initialsSource))}
             </div>
-            <div class="truncate text-xs text-slate-500">${escapeHtml(author ? author.name : "Unknown")}</div>
+            <div class="truncate text-xs text-slate-500">${escapeHtml(authorLabel)}</div>
             <div class="rounded-full px-2 py-0.5 text-[10px] font-medium ${saved ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-500"}">${saved ? "saved" : "open"}</div>
           </div>
           <button type="button" data-route-id="${escapeHtml(route.id)}" class="routeLikeBtn route-like-btn ${isLiked ? "is-liked" : ""} inline-flex items-center gap-1 px-2 py-1 text-xs font-medium">

--- a/static/js/interactions.js
+++ b/static/js/interactions.js
@@ -13,6 +13,10 @@
   };
   const MOCK_VERSION = 3;
 
+  /** One shared cover for cards when no custom image or when the image fails to load. */
+  const ROUTE_CARD_DEFAULT_COVER =
+    "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80";
+
   function nowIso() {
     return new Date().toISOString();
   }
@@ -333,14 +337,19 @@
     return (Math.max(stops, 1) * 0.7 + 0.7).toFixed(1);
   }
 
+  function normalizeRouteCoverUrl(raw) {
+    const s = String(raw || "").trim();
+    if (!s) return null;
+    if (/^https?:\/\//i.test(s)) return s;
+    if (s.startsWith("//")) return `${global.location.protocol}${s}`;
+    if (s.startsWith("/")) return s;
+    return appUrl(s.replace(/^\/*/, ""));
+  }
+
   function routePhoto(route) {
-    if (route?.photoUrl) return String(route.photoUrl);
-    const byId = {
-      r_1: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?auto=format&fit=crop&w=1200&q=80",
-      r_2: "https://images.unsplash.com/photo-1528605248644-14dd04022da1?auto=format&fit=crop&w=1200&q=80",
-      r_3: "https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1200&q=80",
-    };
-    return byId[route?.id] || "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80";
+    const custom = normalizeRouteCoverUrl(route?.photoUrl);
+    if (custom) return custom;
+    return ROUTE_CARD_DEFAULT_COVER;
   }
 
   // Shared interaction used by any page rendering route cards.
@@ -416,7 +425,7 @@
           ${
             showPhotoCover
               ? `<div class="route-thumb relative overflow-hidden border border-slate-200 bg-slate-100">
-                   <img src="${escapeHtml(routePhoto(route))}" alt="${escapeHtml(route.title)} cover photo" class="h-full w-full object-cover" loading="lazy" />
+                   <img src="${escapeHtml(routePhoto(route))}" alt="${escapeHtml(route.title)} cover photo" class="min-h-[120px] h-full w-full object-cover" loading="lazy" data-fallback-cover="${escapeHtml(ROUTE_CARD_DEFAULT_COVER)}" onerror="this.onerror=null;this.src=this.dataset.fallbackCover" />
                    <div class="absolute left-3 top-3 rounded-full px-2 py-1 text-[11px] font-medium" style="background:${badge.bg};color:${badge.color};">${badge.text}</div>
                  </div>`
               : `<div class="route-thumb relative flex items-center justify-center" style="background:${visual.thumbBg};border-color:${visual.thumbBorder};color:${visual.thumbText};">

--- a/static/js/pages/create-route.js
+++ b/static/js/pages/create-route.js
@@ -68,8 +68,39 @@
     let locPendingPhotoUrl = null;
     /** True after user explicitly removes photo so save does not fall back to previous URL. */
     let locPhotoRemoved = false;
+    let routeCoverPendingUrl = null;
+    let routeCoverRemoved = false;
     let draftTimer = null;
     let isSubmitting = false;
+
+    const RT_COVER_STATUS_DEFAULT =
+      "Optional. Remove to use the default cover (same as Explore when no custom image).";
+
+    function currentRouteCoverPhotoUrl() {
+      if (routeCoverRemoved) return null;
+      if (routeCoverPendingUrl) return routeCoverPendingUrl;
+      if (isEdit && editingRoute && editingRoute.photoUrl) return editingRoute.photoUrl;
+      return null;
+    }
+
+    function routeCoverSigForDirty() {
+      return `${routeCoverRemoved}|${currentRouteCoverPhotoUrl() || ""}`;
+    }
+
+    function syncRouteCoverPreview() {
+      $("#errRtCover").addClass("hidden").text("");
+      const url = currentRouteCoverPhotoUrl();
+      if (url) {
+        $("#rtCoverPreview").attr("src", url);
+        $("#rtCoverPreviewWrap").removeClass("hidden");
+        $("#rtCoverStatus").text("Cover set. Remove to use the default.");
+      } else {
+        $("#rtCoverPreview").attr("src", "");
+        $("#rtCoverPreviewWrap").addClass("hidden");
+        $("#rtCoverStatus").text(RT_COVER_STATUS_DEFAULT);
+      }
+      bumpEditDirty();
+    }
 
     let editBaseline = "";
     let editDirtyReady = false;
@@ -86,6 +117,7 @@
           .slice()
           .sort((a, b) => a.order - b.order)
           .map((l) => ({ ...l })),
+        routeCoverSig: routeCoverSigForDirty(),
       });
     }
 
@@ -140,7 +172,7 @@
 
     function clearRouteFieldErrors() {
       $("#routeFormAlert").addClass("hidden").text("");
-      $("#errRtTitle,#errRtTheme,#errRtTags,#errRtLocations,#errLocList").addClass("hidden").text("");
+      $("#errRtTitle,#errRtTheme,#errRtTags,#errRtCover,#errRtLocations,#errLocList").addClass("hidden").text("");
       $("#rtTitle,#rtTheme,#rtTags,#rtDesc").removeClass("border-rose-300 ring-rose-200");
     }
 
@@ -162,6 +194,7 @@
         if (key === "title") $("#errRtTitle").removeClass("hidden").text(text);
         else if (key === "theme") $("#errRtTheme").removeClass("hidden").text(text);
         else if (key === "tags") $("#errRtTags").removeClass("hidden").text(text);
+        else if (key === "photoUrl") $("#errRtCover").removeClass("hidden").text(text);
         else if (key === "locations") $("#errRtLocations").removeClass("hidden").text(text);
         else if (key.startsWith("locations.")) locMsgs.push(text);
         else if (key === "author" || key === "") showRouteAlert(text);
@@ -179,6 +212,8 @@
         description: String($("#rtDesc").val() || "").trim(),
         isPublic: Boolean($("#rtPublic").is(":checked")),
         locations: locations.map((l) => ({ ...l })),
+        routeCoverPendingUrl,
+        routeCoverRemoved,
         savedAt: C.nowIso(),
       };
     }
@@ -238,6 +273,12 @@
         }));
         renumber();
       }
+      if (typeof d.routeCoverRemoved === "boolean") routeCoverRemoved = d.routeCoverRemoved;
+      else routeCoverRemoved = false;
+      routeCoverPendingUrl =
+        d.routeCoverPendingUrl != null && d.routeCoverPendingUrl !== "" ? String(d.routeCoverPendingUrl) : null;
+      $("#rtCover").val("");
+      syncRouteCoverPreview();
       C.showToast("Draft restored.", "success");
     }
 
@@ -260,10 +301,15 @@
         .slice(0, 5)
         .join(" ");
       const visibility = $("#rtPublic").is(":checked") ? "Public" : "Private";
+      const coverUrl = currentRouteCoverPhotoUrl();
+      const coverThumb = coverUrl
+        ? `<div class="mt-3"><img src="${C.escapeHtml(coverUrl)}" alt="" class="max-h-28 w-full max-w-sm rounded-xl border border-slate-200 object-cover" loading="lazy" /></div>`
+        : "";
       $("#routePreview").html(
         `<div class="text-xs font-semibold text-slate-600">${C.escapeHtml(theme)} · ${visibility}</div>
          <div class="mt-1 text-sm font-semibold text-slate-900">${C.escapeHtml(title)}</div>
          <div class="mt-2 text-sm text-slate-700">${C.escapeHtml(desc)}</div>
+         ${coverThumb}
          <div class="mt-2 text-xs text-slate-600">${C.escapeHtml(tags || "No tags")} · ${locations.length} locations</div>`
       );
     }
@@ -394,6 +440,7 @@
         theme,
         tags,
         isPublic,
+        photoUrl: currentRouteCoverPhotoUrl(),
         locations: ordered.map((l, i) => {
           let lat = null;
           let lng = null;
@@ -433,6 +480,12 @@
       $("h1").first().text("Edit route");
     }
 
+    routeCoverPendingUrl = null;
+    routeCoverRemoved = false;
+    $("#rtCover").val("");
+    syncRouteCoverPreview();
+    renderPreview();
+
     $("#btnAddLoc").on("click", () => openLocModal("create"));
     $("#btnCloseLocModal, #btnCancelLoc").on("click", closeLocModal);
 
@@ -444,6 +497,37 @@
       $("#locPhotoPreviewWrap").addClass("hidden");
       $("#errLocPhoto").addClass("hidden").text("");
       $("#locPhotoStatus").text("Photo removed.");
+    });
+
+    $("#btnRemoveRtCover").on("click", () => {
+      routeCoverRemoved = true;
+      routeCoverPendingUrl = null;
+      $("#rtCover").val("");
+      syncRouteCoverPreview();
+      renderPreview();
+      scheduleDraftSave();
+    });
+
+    $("#rtCover").on("change", async (e) => {
+      const file = e.target.files && e.target.files[0];
+      $("#errRtCover").addClass("hidden").text("");
+      if (!file) return;
+      $("#rtCoverStatus").text("Uploading…");
+      try {
+        const url = await uploadPlacePhoto(file);
+        routeCoverPendingUrl = url;
+        routeCoverRemoved = false;
+        $("#rtCoverStatus").text("Cover attached.");
+        syncRouteCoverPreview();
+        renderPreview();
+        scheduleDraftSave();
+      } catch (err) {
+        $("#errRtCover").removeClass("hidden").text(err.message || "Upload failed.");
+        $("#rtCoverStatus").text(RT_COVER_STATUS_DEFAULT);
+        routeCoverPendingUrl = null;
+        $("#rtCover").val("");
+        syncRouteCoverPreview();
+      }
     });
 
     $("#locPhoto").on("change", async (e) => {
@@ -600,6 +684,10 @@
       $("#rtDesc").val("");
       $("#rtTheme").prop("selectedIndex", 0);
       $("#rtPublic").prop("checked", true);
+      routeCoverPendingUrl = null;
+      routeCoverRemoved = false;
+      $("#rtCover").val("");
+      syncRouteCoverPreview();
       locations = [
         { order: 1, time: "10:00", name: "Place name", desc: "Short description", parking: "unknown", photoUrl: null },
       ];
@@ -669,6 +757,7 @@
         editingRoute.description = desc || "No description yet (mock).";
         editingRoute.tags = tags;
         editingRoute.isPublic = isPublic;
+        editingRoute.photoUrl = currentRouteCoverPhotoUrl();
         editingRoute.locations = locations.slice();
         C.writeStore(C.STORAGE_KEYS.routes, routes);
         detachEditGuards();

--- a/static/js/pages/create-route.js
+++ b/static/js/pages/create-route.js
@@ -66,6 +66,8 @@
     let locModalMode = "create";
     let editingLocIndex = -1;
     let locPendingPhotoUrl = null;
+    /** True after user explicitly removes photo so save does not fall back to previous URL. */
+    let locPhotoRemoved = false;
     let draftTimer = null;
     let isSubmitting = false;
 
@@ -314,6 +316,7 @@
       editingLocIndex = typeof idx === "number" ? idx : -1;
       clearLocModalErrors();
       locPendingPhotoUrl = null;
+      locPhotoRemoved = false;
       $("#locPhoto").val("");
       $("#locPhotoStatus").text("");
       $("#locPhotoPreviewWrap").addClass("hidden");
@@ -433,6 +436,16 @@
     $("#btnAddLoc").on("click", () => openLocModal("create"));
     $("#btnCloseLocModal, #btnCancelLoc").on("click", closeLocModal);
 
+    $("#btnRemoveLocPhoto").on("click", () => {
+      locPhotoRemoved = true;
+      locPendingPhotoUrl = null;
+      $("#locPhoto").val("");
+      $("#locPhotoPreview").attr("src", "");
+      $("#locPhotoPreviewWrap").addClass("hidden");
+      $("#errLocPhoto").addClass("hidden").text("");
+      $("#locPhotoStatus").text("Photo removed.");
+    });
+
     $("#locPhoto").on("change", async (e) => {
       const file = e.target.files && e.target.files[0];
       $("#errLocPhoto").addClass("hidden").text("");
@@ -441,6 +454,7 @@
       try {
         const url = await uploadPlacePhoto(file);
         locPendingPhotoUrl = url;
+        locPhotoRemoved = false;
         $("#locPhotoPreview").attr("src", url);
         $("#locPhotoPreviewWrap").removeClass("hidden");
         $("#locPhotoStatus").text("Photo attached.");
@@ -472,7 +486,9 @@
       }
       if (!modalOk) return;
 
-      const photoUrl = locPendingPhotoUrl || (locModalMode === "edit" ? locations[editingLocIndex]?.photoUrl : null) || null;
+      const photoUrl = locPhotoRemoved
+        ? null
+        : locPendingPhotoUrl || (locModalMode === "edit" ? locations[editingLocIndex]?.photoUrl : null) || null;
 
       const prev = locModalMode === "edit" ? locations[editingLocIndex] : null;
       const loc = {

--- a/static/js/pages/create-route.js
+++ b/static/js/pages/create-route.js
@@ -9,7 +9,7 @@
   const DRAFT_KEY = "mv_create_route_draft_v1";
   const DRAFT_DEBOUNCE_MS = 1200;
 
-  function mountCreate() {
+  async function mountCreate() {
     C.requireAuthOrRedirect();
     C.seedIfEmpty();
     C.mountNav();
@@ -17,13 +17,48 @@
     const session = C.getSession();
     const users = C.readStore(C.STORAGE_KEYS.users, []);
     const me = users.find((u) => u.id === session.userId) || users[0];
+    const boot = window.MYVIBE_BOOTSTRAP || {};
 
     const routes = C.readStore(C.STORAGE_KEYS.routes, []);
     const savedLocations = C.readStore(C.STORAGE_KEYS.locations, []);
     const editRouteId = C.getQueryParam("r");
     const mode = C.getQueryParam("mode");
-    const editingRoute = routes.find((r) => r.id === editRouteId);
-    const isEdit = mode === "edit" && editingRoute && editingRoute.authorId === me.id;
+
+    let editingRoute = null;
+    let isEdit = false;
+    let serverEditId = null;
+
+    const editIdStr = editRouteId != null ? String(editRouteId).trim() : "";
+    if (mode === "edit" && editIdStr) {
+      if (/^\d+$/.test(editIdStr)) {
+        if (!boot.isAuthenticated || boot.userId == null) {
+          C.showToast("Please sign in to edit this route.", "error");
+          window.location.href = C.appUrl("login");
+          return;
+        }
+        try {
+          const data = await C.fetchJson(`api/routes/${encodeURIComponent(editIdStr)}`);
+          if (!data?.ok || !data.route) throw new Error("Not found");
+          const r = data.route;
+          if (Number(r.authorId) !== Number(boot.userId)) {
+            C.showToast("You can only edit your own routes.", "error");
+            window.location.href = C.routeDetailUrl(editIdStr);
+            return;
+          }
+          editingRoute = { ...r, id: String(r.id) };
+          isEdit = true;
+          serverEditId = Number(editIdStr);
+        } catch (err) {
+          const msg = err.body?.error || err.message || "Route not found.";
+          C.showToast(String(msg), "error");
+          window.location.href = C.appUrl("dashboard");
+          return;
+        }
+      } else {
+        editingRoute = routes.find((rr) => String(rr.id) === editIdStr) || null;
+        isEdit = Boolean(editingRoute && editingRoute.authorId === me.id);
+      }
+    }
 
     let locations = isEdit
       ? (editingRoute.locations || []).slice().sort((a, b) => a.order - b.order)
@@ -33,6 +68,63 @@
     let locPendingPhotoUrl = null;
     let draftTimer = null;
     let isSubmitting = false;
+
+    let editBaseline = "";
+    let editDirtyReady = false;
+    let editDirty = false;
+
+    function collectRouteStateForDirty() {
+      return JSON.stringify({
+        title: String($("#rtTitle").val() || "").trim(),
+        theme: String($("#rtTheme").val() || "").trim(),
+        tags: String($("#rtTags").val() || "").trim(),
+        description: String($("#rtDesc").val() || "").trim(),
+        isPublic: Boolean($("#rtPublic").is(":checked")),
+        locations: locations
+          .slice()
+          .sort((a, b) => a.order - b.order)
+          .map((l) => ({ ...l })),
+      });
+    }
+
+    function resetEditDirtyBaseline() {
+      if (!isEdit) return;
+      editBaseline = collectRouteStateForDirty();
+      editDirtyReady = true;
+    }
+
+    function bumpEditDirty() {
+      if (!isEdit || !editDirtyReady) return;
+      editDirty = collectRouteStateForDirty() !== editBaseline;
+    }
+
+    function detachEditGuards() {
+      $(window).off("beforeunload.mvEditRoute");
+      $(document).off("click.mvEditRouteGuard");
+    }
+
+    function attachEditGuards() {
+      if (!isEdit) return;
+      $(window).on("beforeunload.mvEditRoute", (ev) => {
+        if (!editDirty) return;
+        ev.preventDefault();
+        ev.returnValue = "";
+      });
+      $(document).on("click.mvEditRouteGuard", "a[href]", function (ev) {
+        if (!editDirty) return;
+        const href = this.getAttribute("href");
+        if (!href || href === "#" || href.startsWith("javascript:")) return;
+        try {
+          const u = new URL(href, window.location.origin);
+          if (u.origin !== window.location.origin) return;
+        } catch {
+          return;
+        }
+        if (!window.confirm("You have unsaved changes. Leave without saving?")) {
+          ev.preventDefault();
+        }
+      });
+    }
 
     function mapParkingLabel(v) {
       if (v === "yes") return "Yes";
@@ -151,7 +243,8 @@
       isSubmitting = on;
       const $btn = $("#btnSubmitRoute");
       $btn.prop("disabled", on);
-      $btn.text(on ? "Saving…" : "Save route");
+      const idle = isEdit ? "Save changes" : "Save route";
+      $btn.text(on ? "Saving…" : idle);
     }
 
     function renderPreview() {
@@ -213,6 +306,7 @@
         .join("");
       $("#locList").html(html || C.emptyCard("No locations yet. Add one from the button above."));
       renderPreview();
+      bumpEditDirty();
     }
 
     function openLocModal(modeName, idx) {
@@ -297,14 +391,28 @@
         theme,
         tags,
         isPublic,
-        locations: ordered.map((l, i) => ({
-          order: i + 1,
-          name: String(l.name || "").trim(),
-          time: String(l.time || "").trim(),
-          desc: String(l.desc || "").trim(),
-          parking: String(l.parking || "unknown").trim() || "unknown",
-          photoUrl: l.photoUrl || null,
-        })),
+        locations: ordered.map((l, i) => {
+          let lat = null;
+          let lng = null;
+          if (l.lat != null && l.lat !== "") {
+            const x = Number(l.lat);
+            if (Number.isFinite(x)) lat = x;
+          }
+          if (l.lng != null && l.lng !== "") {
+            const y = Number(l.lng);
+            if (Number.isFinite(y)) lng = y;
+          }
+          return {
+            order: i + 1,
+            name: String(l.name || "").trim(),
+            time: String(l.time || "").trim(),
+            desc: String(l.desc || "").trim(),
+            parking: String(l.parking || "unknown").trim() || "unknown",
+            photoUrl: l.photoUrl || null,
+            lat,
+            lng,
+          };
+        }),
       };
     }
 
@@ -366,13 +474,16 @@
 
       const photoUrl = locPendingPhotoUrl || (locModalMode === "edit" ? locations[editingLocIndex]?.photoUrl : null) || null;
 
+      const prev = locModalMode === "edit" ? locations[editingLocIndex] : null;
       const loc = {
-        order: locModalMode === "edit" ? locations[editingLocIndex].order : locations.length + 1,
+        order: locModalMode === "edit" && prev ? prev.order : locations.length + 1,
         name,
         time,
         desc: desc || "No description.",
         parking,
         photoUrl,
+        lat: prev && prev.lat != null && prev.lat !== "" ? prev.lat : null,
+        lng: prev && prev.lng != null && prev.lng !== "" ? prev.lng : null,
       };
 
       if (locModalMode === "edit" && editingLocIndex >= 0) locations[editingLocIndex] = loc;
@@ -450,10 +561,12 @@
     $("#rtTitle, #rtTheme, #rtTags, #rtDesc").on("input", () => {
       renderPreview();
       scheduleDraftSave();
+      bumpEditDirty();
     });
     $("#rtPublic").on("change", () => {
       renderPreview();
       scheduleDraftSave();
+      bumpEditDirty();
     });
 
     $("#btnSaveDraft").on("click", () => {
@@ -483,25 +596,53 @@
       e.preventDefault();
       if (isSubmitting) return;
 
-      const title = String($("#rtTitle").val() || "").trim();
-      const theme = String($("#rtTheme").val() || "").trim();
-      const desc = String($("#rtDesc").val() || "").trim();
-      const tagsRaw = String($("#rtTags").val() || "");
-      const isPublic = Boolean($("#rtPublic").is(":checked"));
+      if (isEdit && serverEditId != null) {
+        clearRouteFieldErrors();
+        if (!validateRouteClient()) {
+          C.showToast("Fix the highlighted fields.", "error");
+          return;
+        }
+        setSubmitting(true);
+        try {
+          const data = await C.fetchJson(`api/routes/${serverEditId}`, {
+            method: "PATCH",
+            body: buildCreatePayload(),
+          });
+          if (!data.ok || !data.route) throw new Error("Unexpected response.");
+          setSubmitting(false);
+          detachEditGuards();
+          editDirty = false;
+          C.showToast("Route updated.", "success");
+          window.setTimeout(() => {
+            window.location.href = C.routeDetailUrl(String(data.route.id));
+          }, 400);
+        } catch (err) {
+          setSubmitting(false);
+          const body = err.body || {};
+          if (err.status === 403) {
+            C.showToast("You can only edit your own routes.", "error");
+          } else if (body.errors && typeof body.errors === "object") {
+            applyServerErrors(body.errors);
+            C.showToast("Save failed — check the form.", "error");
+          } else {
+            showRouteAlert(err.message || "Could not update route.");
+            C.showToast("Save failed.", "error");
+          }
+        }
+        return;
+      }
 
-      if (isEdit) {
-        if (!title) {
-          $("#errRtTitle").removeClass("hidden").text("Please enter a title.");
+      if (isEdit && editingRoute) {
+        clearRouteFieldErrors();
+        if (!validateRouteClient()) {
+          C.showToast("Fix the highlighted fields.", "error");
           return;
         }
-        if (!theme) {
-          $("#errRtTheme").removeClass("hidden").text("Please select a theme.");
-          return;
-        }
-        if (locations.length === 0) {
-          $("#errRtLocations").removeClass("hidden").text("Please add at least one location.");
-          return;
-        }
+        const title = String($("#rtTitle").val() || "").trim();
+        const theme = String($("#rtTheme").val() || "").trim();
+        const desc = String($("#rtDesc").val() || "").trim();
+        const tagsRaw = String($("#rtTags").val() || "");
+        const isPublic = Boolean($("#rtPublic").is(":checked"));
         const tags = tagsRaw
           .split(",")
           .map((t) => t.trim().replaceAll("#", ""))
@@ -514,6 +655,8 @@
         editingRoute.isPublic = isPublic;
         editingRoute.locations = locations.slice();
         C.writeStore(C.STORAGE_KEYS.routes, routes);
+        detachEditGuards();
+        editDirty = false;
         C.showToast("Route updated (mock).", "success");
         window.setTimeout(() => {
           window.location.href = C.routeDetailUrl(editingRoute.id);
@@ -552,9 +695,14 @@
     renderSavedLocationSelect();
     renderLocs();
     renderPreview();
+
+    if (isEdit) {
+      attachEditGuards();
+      window.setTimeout(() => resetEditDirtyBaseline(), 0);
+    }
   }
 
   $(document).ready(() => {
-    if ($("body").attr("data-page") === "create") mountCreate();
+    if ($("body").attr("data-page") === "create") void mountCreate();
   });
 })();

--- a/static/js/pages/dashboard.js
+++ b/static/js/pages/dashboard.js
@@ -6,20 +6,58 @@
   const C = window.AppCore;
   if (!C) return;
 
-  function mountDashboard() {
+  function normalizeServerRoute(r) {
+    if (!r || typeof r !== "object") return null;
+    return { ...r, id: String(r.id), authorId: r.authorId };
+  }
+
+  async function mountDashboard() {
     C.requireAuthOrRedirect();
     C.seedIfEmpty();
     C.mountNav();
 
     const users = C.readStore(C.STORAGE_KEYS.users, []);
-    const routes = C.readStore(C.STORAGE_KEYS.routes, []);
     const saved = C.readStore(C.STORAGE_KEYS.saved, []);
     const session = C.getSession();
-    const myRoutes = routes.filter((r) => r.authorId === session.userId);
+    const boot = window.MYVIBE_BOOTSTRAP || {};
 
-    $("#statRoutes").text(routes.length);
-    $("#statMyRoutes").text(myRoutes.length);
-    $("#statTopTheme").text(C.topTheme(routes) || "—");
+    const mockRoutes = C.readStore(C.STORAGE_KEYS.routes, []);
+    const mockMyCount = mockRoutes.filter((r) => r.authorId === session.userId).length;
+
+    let routes = mockRoutes;
+    let statTotal = routes.length;
+    let statMyRoutes = mockMyCount;
+    let statTopTheme = C.topTheme(routes) || "—";
+    let usingServerFeed = false;
+
+    if (boot.isAuthenticated) {
+      try {
+        const [pubData, myData] = await Promise.all([
+          C.fetchJson("api/routes/public"),
+          C.fetchJson("api/my-routes"),
+        ]);
+        const rawPub = Array.isArray(pubData?.routes) ? pubData.routes : [];
+        const normalized = rawPub.map(normalizeServerRoute).filter(Boolean);
+        routes = normalized;
+        statTotal = normalized.length;
+        statMyRoutes = Array.isArray(myData?.routes) ? myData.routes.length : 0;
+        statTopTheme = C.topTheme(normalized) || "—";
+        usingServerFeed = true;
+      } catch {
+        C.showToast("Could not load live routes — showing saved demo data.", "error");
+        routes = mockRoutes;
+        statTotal = mockRoutes.length;
+        statMyRoutes = mockMyCount;
+        statTopTheme = C.topTheme(mockRoutes) || "—";
+        usingServerFeed = false;
+      }
+    }
+
+    $("#statRoutes").text(statTotal);
+    $("#statMyRoutes").text(statMyRoutes);
+    $("#statTopTheme").text(statTopTheme);
+    $("#dashStatRoutesNote").text(usingServerFeed ? "Public routes (server)" : "Using mock data");
+    $("#dashStatThemeNote").text(usingServerFeed ? "From public feed" : "Mock metric");
 
     function renderHomeLists() {
       const q = String($("#homeSearch").val() || "").trim().toLowerCase();
@@ -27,9 +65,13 @@
       if (q) {
         items = items.filter((r) => {
           return (
-            r.title.toLowerCase().includes(q) ||
-            r.description.toLowerCase().includes(q) ||
-            (r.tags || []).some((t) => t.toLowerCase().includes(q))
+            String(r.title || "")
+              .toLowerCase()
+              .includes(q) ||
+            String(r.description || "")
+              .toLowerCase()
+              .includes(q) ||
+            (r.tags || []).some((t) => String(t || "").toLowerCase().includes(q))
           );
         });
       }
@@ -40,14 +82,16 @@
         .slice(0, 6);
       const latest = items
         .slice()
-        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+        .sort((a, b) => (String(a.createdAt || "") < String(b.createdAt || "") ? 1 : -1))
         .slice(0, 6);
 
       $("#popularRoutes").html(
-        popular.map((r) => C.routeCardHtml(r, users, saved, { showPhotoCover: true })).join("") || C.emptyCard("No popular routes found.")
+        popular.map((r) => C.routeCardHtml(r, users, saved, { showPhotoCover: true })).join("") ||
+          C.emptyCard("No popular routes found.")
       );
       $("#latestRoutes").html(
-        latest.map((r) => C.routeCardHtml(r, users, saved, { showPhotoCover: true })).join("") || C.emptyCard("No latest routes found.")
+        latest.map((r) => C.routeCardHtml(r, users, saved, { showPhotoCover: true })).join("") ||
+          C.emptyCard("No latest routes found.")
       );
     }
 
@@ -56,6 +100,6 @@
   }
 
   $(document).ready(() => {
-    if ($("body").attr("data-page") === "dashboard") mountDashboard();
+    if ($("body").attr("data-page") === "dashboard") void mountDashboard();
   });
 })();

--- a/static/js/pages/profile.js
+++ b/static/js/pages/profile.js
@@ -70,19 +70,29 @@
       setTab(String($(this).attr("data-tab")));
     });
 
-    $("#myRoutesGrid").on("click", ".btnDeleteMyRoute", function () {
+    $("#myRoutesGrid").on("click", ".btnDeleteMyRoute", async function () {
       const routeId = String($(this).attr("data-route-id") || "");
       if (!routeId) return;
+      if (!window.confirm("Delete this route? This cannot be undone.")) return;
       if (/^\d+$/.test(routeId)) {
-        C.showToast("Delete is not available yet.", "error");
+        try {
+          await C.fetchJson(`api/routes/${encodeURIComponent(routeId)}`, { method: "DELETE" });
+        } catch (err) {
+          if (err.status === 403) C.showToast("You can only delete your own routes.", "error");
+          else C.showToast(err.body?.error || err.message || "Could not delete route.", "error");
+          return;
+        }
+        const nextSaved = C.readStore(C.STORAGE_KEYS.saved, []).filter((id) => String(id) !== routeId);
+        C.writeStore(C.STORAGE_KEYS.saved, nextSaved);
+        await renderPanels();
+        C.showToast("Route deleted.", "success");
         return;
       }
-      if (!window.confirm("Delete this route?")) return;
       const nextRoutes = C.readStore(C.STORAGE_KEYS.routes, []).filter((r) => r.id !== routeId);
       C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
       const nextSaved = C.readStore(C.STORAGE_KEYS.saved, []).filter((id) => id !== routeId);
       C.writeStore(C.STORAGE_KEYS.saved, nextSaved);
-      renderPanels();
+      await renderPanels();
       C.showToast("Route deleted (mock).", "success");
     });
 

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -202,14 +202,6 @@
     if (isOwner) {
       $("#ownerActions").removeClass("hidden");
       $("#btnEditRoute").attr("href", C.createRouteUrl(route.id, "edit"));
-      if (numericId) {
-        $("#btnEditRoute")
-          .off("click.dbEdit")
-          .on("click.dbEdit", (e) => {
-            e.preventDefault();
-            C.showToast("Editing server-saved routes is coming soon.", "info");
-          });
-      }
     }
 
     $("#btnLike").on("click", () => {
@@ -309,13 +301,25 @@
     });
     $("#btnReport").on("click", () => C.showToast("Report submitted. Thanks for your feedback.", "success"));
 
-    $("#btnDeleteRoute").on("click", () => {
+    $("#btnDeleteRoute").on("click", async () => {
       if (!isOwner) return;
+      if (!window.confirm("Delete this route? This action cannot be undone.")) return;
       if (numericId) {
-        C.showToast("Deleting server-saved routes is not available yet.", "info");
+        try {
+          await C.fetchJson(`api/routes/${encodeURIComponent(String(route.id))}`, { method: "DELETE" });
+        } catch (err) {
+          if (err.status === 403) C.showToast("You can only delete your own routes.", "error");
+          else C.showToast(err.body?.error || err.message || "Could not delete route.", "error");
+          return;
+        }
+        const nextSaved = (saved || []).filter((id) => String(id) !== String(route.id));
+        C.writeStore(C.STORAGE_KEYS.saved, nextSaved);
+        C.showToast("Route deleted.", "success");
+        window.setTimeout(() => {
+          window.location.href = C.appUrl("dashboard");
+        }, 350);
         return;
       }
-      if (!window.confirm("Delete this route? This action cannot be undone.")) return;
       const nextRoutes = routes.filter((r) => r.id !== route.id);
       C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
       const nextSaved = (saved || []).filter((id) => id !== route.id);

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -6,9 +6,11 @@
   const C = window.AppCore;
   if (!C) return;
   const COMMENTS_KEY = "mv_route_comments_v1";
+  const CREATE_DRAFT_KEY = "mv_create_route_draft_v1";
 
   function commentsStore() {
-    return C.readStore(COMMENTS_KEY, {});
+    const store = C.readStore(COMMENTS_KEY, {});
+    return store && typeof store === "object" ? store : {};
   }
 
   function writeCommentsStore(store) {
@@ -18,7 +20,8 @@
   function routeComments(routeId) {
     const key = String(routeId || "");
     const store = commentsStore();
-    return Array.isArray(store[key]) ? store[key] : [];
+    const list = store[key];
+    return Array.isArray(list) ? list : [];
   }
 
   function saveRouteComments(routeId, comments) {
@@ -112,7 +115,7 @@
     const routes = C.readStore(C.STORAGE_KEYS.routes, []);
     const saved = C.readStore(C.STORAGE_KEYS.saved, []);
     const session = C.getSession();
-    const boot = global.MYVIBE_BOOTSTRAP || {};
+    const boot = window.MYVIBE_BOOTSTRAP || {};
 
     const pathParts = window.location.pathname.split("/").filter(Boolean);
     const pathRouteId = pathParts[0] === "route" ? decodeURIComponent(pathParts[1] || "") : "";
@@ -121,8 +124,8 @@
 
     let route = null;
     if (numericId) {
-      if (global.MYVIBE_ROUTE) {
-        route = { ...global.MYVIBE_ROUTE, id: String(global.MYVIBE_ROUTE.id) };
+      if (window.MYVIBE_ROUTE) {
+        route = { ...window.MYVIBE_ROUTE, id: String(window.MYVIBE_ROUTE.id) };
       } else {
         try {
           const data = await C.fetchJson(`api/routes/${encodeURIComponent(routeId)}`);
@@ -259,26 +262,39 @@
         C.showToast("Please sign in first.", "error");
         return;
       }
-      const nextRoutes = C.readStore(C.STORAGE_KEYS.routes, []);
-      const nextId = `r_${Math.floor(Math.random() * 1000000)}`;
-      const cloned = {
-        ...route,
-        id: nextId,
-        authorId: me.userId,
-        authorUsername: me.username,
-        title: route.title,
-        createdAt: C.nowIso(),
-        updatedAt: C.nowIso(),
-        locations: (route.locations || [])
-          .slice()
-          .sort((a, b) => a.order - b.order)
-          .map((loc, i) => ({ ...loc, order: i + 1 })),
+
+      const orderedLocations = (route.locations || [])
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .map((loc, i) => ({
+          order: i + 1,
+          name: String(loc.name || "").trim(),
+          time: String(loc.time || "").trim(),
+          desc: String(loc.desc || loc.description || "").trim(),
+          parking: String(loc.parking || "unknown").trim() || "unknown",
+          photoUrl: loc.photoUrl || null,
+        }));
+
+      const duplicateDraft = {
+        title: String(route.title || "").trim(),
+        theme: String(route.theme || "").trim(),
+        tags: (route.tags || []).join(", "),
+        description: String(route.description || "").trim(),
+        isPublic: Boolean(route.isPublic),
+        locations: orderedLocations,
+        savedAt: C.nowIso(),
       };
-      nextRoutes.push(cloned);
-      C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
-      C.showToast("Route duplicated. Opening edit mode…", "success");
+
+      try {
+        window.localStorage.setItem(CREATE_DRAFT_KEY, JSON.stringify(duplicateDraft));
+      } catch {
+        C.showToast("Could not prepare duplicate draft.", "error");
+        return;
+      }
+
+      C.showToast("Duplicate loaded. Opening create route…", "success");
       window.setTimeout(() => {
-        window.location.href = C.createRouteUrl(nextId, "edit");
+        window.location.href = C.appUrl("create-route");
       }, 350);
     });
 

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -5,6 +5,103 @@
 (function routePage() {
   const C = window.AppCore;
   if (!C) return;
+  const COMMENTS_KEY = "mv_route_comments_v1";
+
+  function commentsStore() {
+    return C.readStore(COMMENTS_KEY, {});
+  }
+
+  function writeCommentsStore(store) {
+    C.writeStore(COMMENTS_KEY, store);
+  }
+
+  function routeComments(routeId) {
+    const key = String(routeId || "");
+    const store = commentsStore();
+    return Array.isArray(store[key]) ? store[key] : [];
+  }
+
+  function saveRouteComments(routeId, comments) {
+    const key = String(routeId || "");
+    const store = commentsStore();
+    store[key] = comments;
+    writeCommentsStore(store);
+  }
+
+  function timeAgoLabel(iso) {
+    const ts = new Date(iso).getTime();
+    if (!Number.isFinite(ts)) return "just now";
+    const diffMin = Math.max(0, Math.floor((Date.now() - ts) / 60000));
+    if (diffMin < 1) return "just now";
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour}h ago`;
+    const diffDay = Math.floor(diffHour / 24);
+    return `${diffDay}d ago`;
+  }
+
+  function renderComments(routeId) {
+    const list = routeComments(routeId);
+    if (!list.length) {
+      $("#commentList").html(
+        `<div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">No comments yet. Be the first to comment.</div>`
+      );
+      return;
+    }
+    $("#commentList").html(
+      list
+        .slice()
+        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+        .map(
+          (c) => `
+        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
+          <div class="text-xs font-semibold text-slate-600">${C.escapeHtml(c.author)} · ${C.escapeHtml(timeAgoLabel(c.createdAt))}</div>
+          <div class="mt-2">${C.escapeHtml(c.text)}</div>
+        </div>
+      `
+        )
+        .join("")
+    );
+  }
+
+  function renderSimilarRoutes(route, routes) {
+    const currentTags = new Set((route.tags || []).map((t) => String(t || "").toLowerCase()));
+    const currentTheme = String(route.theme || "").toLowerCase();
+    const similar = routes
+      .filter((r) => String(r.id) !== String(route.id))
+      .map((r) => {
+        const rTags = (r.tags || []).map((t) => String(t || "").toLowerCase());
+        const overlap = rTags.filter((t) => currentTags.has(t)).length;
+        let score = 0;
+        if (String(r.theme || "").toLowerCase() === currentTheme && currentTheme) score += 2;
+        score += overlap;
+        return { route: r, score };
+      })
+      .filter((x) => x.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 4)
+      .map((x) => x.route);
+
+    if (!similar.length) {
+      $("#similarRoutes").html(
+        `<div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">No similar routes available yet.</div>`
+      );
+      return;
+    }
+    $("#similarRoutes").html(
+      similar
+        .map(
+          (r) => `
+        <a href="${C.routeDetailUrl(r.id)}" class="rounded-2xl border border-slate-200 bg-white p-4 text-sm shadow-sm hover:bg-slate-50">
+          <div class="text-xs font-semibold text-slate-600">${C.escapeHtml(r.theme || "—")}</div>
+          <div class="mt-1 font-semibold text-slate-900">${C.escapeHtml(r.title || "Untitled route")}</div>
+          <div class="mt-2 text-slate-600">${C.escapeHtml((r.tags || []).slice(0, 3).map((t) => `#${t}`).join(" "))}</div>
+        </a>
+      `
+        )
+        .join("")
+    );
+  }
 
   async function mountRoute() {
     C.requireAuthOrRedirect();
@@ -47,10 +144,15 @@
     }
 
     const author = users.find((u) => u.id === route.authorId);
-    const authorLabel = route.authorUsername || (author ? author.name : "Unknown");
+    const authorLabel = route.authorUsername || (author ? author.username || author.name : "Unknown");
     $("#routeTitle").text(route.title);
     $("#routeTheme").text(route.theme);
     $("#routeAuthor").text(authorLabel);
+    if (authorLabel && authorLabel !== "Unknown") {
+      $("#routeAuthorLink").attr("href", C.appUrl(`user/${encodeURIComponent(String(authorLabel).toLowerCase())}`));
+    } else {
+      $("#routeAuthorLink").attr("href", "#");
+    }
     const createdLabel = route.createdAt ? C.formatDate(route.createdAt) : "—";
     $("#routeMeta").text(`${createdLabel} · ${route.locations.length} stops · ★ ${route.rating ?? 4}`);
     $("#routeDesc").text(route.description);
@@ -83,6 +185,8 @@
       })
       .join("");
     $("#routeLocations").html(locHtml);
+    renderSimilarRoutes(route, routes);
+    renderComments(route.id);
 
     const savedSet = new Set(saved || []);
     C.updateRouteButtons(route, savedSet);
@@ -131,7 +235,63 @@
       }
     });
 
-    $("#btnCmt").on("click", () => C.showToast("Comment section is placeholder only.", "info"));
+    $("#btnCmt").on("click", () => {
+      const text = String($("#cmt").val() || "").trim();
+      if (!text) {
+        C.showToast("Please enter a comment.", "error");
+        return;
+      }
+      const next = routeComments(route.id);
+      next.push({
+        author: boot.username || session?.username || "you",
+        text,
+        createdAt: C.nowIso(),
+      });
+      saveRouteComments(route.id, next);
+      $("#cmt").val("");
+      renderComments(route.id);
+      C.showToast("Comment added.", "success");
+    });
+
+    $("#btnDuplicate").on("click", () => {
+      const me = session || C.getSession();
+      if (!me) {
+        C.showToast("Please sign in first.", "error");
+        return;
+      }
+      const nextRoutes = C.readStore(C.STORAGE_KEYS.routes, []);
+      const nextId = `r_${Math.floor(Math.random() * 1000000)}`;
+      const cloned = {
+        ...route,
+        id: nextId,
+        authorId: me.userId,
+        authorUsername: me.username,
+        title: `${route.title} (copy)`,
+        createdAt: C.nowIso(),
+        updatedAt: C.nowIso(),
+        locations: (route.locations || [])
+          .slice()
+          .sort((a, b) => a.order - b.order)
+          .map((loc, i) => ({ ...loc, order: i + 1 })),
+      };
+      nextRoutes.push(cloned);
+      C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
+      C.showToast("Route duplicated to your account.", "success");
+      window.setTimeout(() => {
+        window.location.href = C.routeDetailUrl(nextId);
+      }, 350);
+    });
+
+    $("#btnCompleted").on("click", () => C.showToast("Marked as completed.", "success"));
+    $("#btnSubmitRating").on("click", () => {
+      const rating = String($("#ratingSelect").val() || "").trim();
+      if (!rating) {
+        C.showToast("Please choose a rating first.", "error");
+        return;
+      }
+      C.showToast(`Rating submitted: ${rating}/5.`, "success");
+    });
+    $("#btnReport").on("click", () => C.showToast("Report submitted. Thanks for your feedback.", "success"));
 
     $("#btnDeleteRoute").on("click", () => {
       if (!isOwner) return;

--- a/static/js/pages/route.js
+++ b/static/js/pages/route.js
@@ -253,7 +253,7 @@
       C.showToast("Comment added.", "success");
     });
 
-    $("#btnDuplicate").on("click", () => {
+    $("#btnDuplicate").on("click", async () => {
       const me = session || C.getSession();
       if (!me) {
         C.showToast("Please sign in first.", "error");
@@ -266,7 +266,7 @@
         id: nextId,
         authorId: me.userId,
         authorUsername: me.username,
-        title: `${route.title} (copy)`,
+        title: route.title,
         createdAt: C.nowIso(),
         updatedAt: C.nowIso(),
         locations: (route.locations || [])
@@ -276,9 +276,9 @@
       };
       nextRoutes.push(cloned);
       C.writeStore(C.STORAGE_KEYS.routes, nextRoutes);
-      C.showToast("Route duplicated to your account.", "success");
+      C.showToast("Route duplicated. Opening edit mode…", "success");
       window.setTimeout(() => {
-        window.location.href = C.routeDetailUrl(nextId);
+        window.location.href = C.createRouteUrl(nextId, "edit");
       }, 350);
     });
 

--- a/templates/create_route.html
+++ b/templates/create_route.html
@@ -74,6 +74,29 @@
           ></textarea>
         </div>
 
+        <div>
+          <label class="text-sm font-medium text-slate-700" for="rtCover">Cover image (optional)</label>
+          <input
+            id="rtCover"
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            class="mt-2 block w-full text-sm text-slate-700 file:mr-3 file:rounded-lg file:border-0 file:bg-slate-900 file:px-3 file:py-2 file:text-xs file:font-semibold file:text-white"
+          />
+          <p id="rtCoverStatus" class="mt-1 text-xs text-slate-500"></p>
+          <p id="errRtCover" class="mt-1 hidden text-xs font-semibold text-rose-600"></p>
+          <div id="rtCoverPreviewWrap" class="mt-2 hidden space-y-2">
+            <img id="rtCoverPreview" src="" alt="Route cover preview" class="max-h-40 w-full max-w-md rounded-xl border border-slate-200 object-cover" />
+            <button
+              id="btnRemoveRtCover"
+              type="button"
+              class="rounded-xl border border-rose-200 bg-white px-3 py-2 text-xs font-semibold text-rose-800 shadow-sm hover:bg-rose-50"
+            >
+              Remove photo
+            </button>
+          </div>
+          <p class="mt-1 text-xs text-slate-500">If you skip this, the default cover is used (same idea as Explore cards).</p>
+        </div>
+
         <div id="routePreview" class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
           Preview will update as you type.
         </div>

--- a/templates/create_route.html
+++ b/templates/create_route.html
@@ -211,8 +211,15 @@
         <input id="locPhoto" type="file" accept="image/png,image/jpeg,image/gif,image/webp" class="mt-2 block w-full text-sm text-slate-700 file:mr-3 file:rounded-lg file:border-0 file:bg-slate-900 file:px-3 file:py-2 file:text-xs file:font-semibold file:text-white" />
         <p id="locPhotoStatus" class="mt-1 text-xs text-slate-500"></p>
         <p id="errLocPhoto" class="mt-1 hidden text-xs font-semibold text-rose-600"></p>
-        <div id="locPhotoPreviewWrap" class="mt-2 hidden">
+        <div id="locPhotoPreviewWrap" class="mt-2 hidden space-y-2">
           <img id="locPhotoPreview" src="" alt="Location preview" class="max-h-40 rounded-xl border border-slate-200 object-cover" />
+          <button
+            id="btnRemoveLocPhoto"
+            type="button"
+            class="rounded-xl border border-rose-200 bg-white px-3 py-2 text-xs font-semibold text-rose-800 shadow-sm hover:bg-rose-50"
+          >
+            Remove photo
+          </button>
         </div>
       </div>
       <div class="flex gap-2">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -40,12 +40,12 @@
     <div class="rounded-2xl border border-slate-200 bg-white/70 p-5 shadow-sm backdrop-blur">
       <div class="text-xs font-semibold text-slate-600">Total routes</div>
       <div id="statRoutes" class="mt-2 text-3xl font-semibold">—</div>
-      <div class="mt-1 text-sm text-slate-600">Using mock data</div>
+      <div id="dashStatRoutesNote" class="mt-1 text-sm text-slate-600">—</div>
     </div>
     <div class="rounded-2xl border border-slate-200 bg-white/70 p-5 shadow-sm backdrop-blur">
       <div class="text-xs font-semibold text-slate-600">Top theme</div>
       <div id="statTopTheme" class="mt-2 text-3xl font-semibold">—</div>
-      <div class="mt-1 text-sm text-slate-600">Mock metric</div>
+      <div id="dashStatThemeNote" class="mt-1 text-sm text-slate-600">—</div>
     </div>
     <div class="rounded-2xl border border-slate-200 bg-white/70 p-5 shadow-sm backdrop-blur">
       <div class="text-xs font-semibold text-slate-600">My routes</div>

--- a/templates/route.html
+++ b/templates/route.html
@@ -16,7 +16,7 @@
           <span id="routeTheme" class="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white">
             {{ route.theme if route else '—' }}
           </span>
-          <span>by <span id="routeAuthor" class="font-semibold text-slate-800">{{ route.author if route else '—' }}</span></span>
+          <span>by <a id="routeAuthorLink" href="#" class="font-semibold text-slate-800 hover:text-sky-800"><span id="routeAuthor">{{ route.author if route else '—' }}</span></a></span>
           <span class="text-slate-400">·</span>
           <span id="routeMeta">{{ route.meta if route else '—' }}</span>
         </div>
@@ -29,6 +29,7 @@
         <button id="btnLike" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50" type="button">❤ Like</button>
         <button id="btnSave" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50" type="button">🔖 Save</button>
         <button id="btnShare" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-800" type="button">Share</button>
+        <button id="btnDuplicate" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50" type="button">Duplicate</button>
       </div>
     </div>
 
@@ -69,33 +70,41 @@
     </section>
 
     <aside class="rounded-3xl border border-slate-200 bg-white/70 p-5 shadow-sm backdrop-blur">
-      <div class="text-sm font-semibold text-slate-900">Comments (optional)</div>
-      <p class="mt-1 text-sm text-slate-600">Simple placeholder section</p>
-
-      <div class="mt-4 space-y-3">
-        {% for comment in comments %}
-        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-          <div class="text-xs font-semibold text-slate-600">{{ comment.author }} · {{ comment.time }}</div>
-          <div class="mt-2">{{ comment.text }}</div>
+      <div class="rounded-2xl border border-slate-200 bg-white p-4">
+        <div class="text-xs font-semibold uppercase tracking-wide text-slate-600">Route actions</div>
+        <div class="mt-3 grid gap-2">
+          <button id="btnCompleted" type="button" class="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-50">
+            Mark as completed
+          </button>
+          <div class="flex items-center gap-2">
+            <label for="ratingSelect" class="text-sm font-semibold text-slate-700">Rate</label>
+            <select id="ratingSelect" class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-900">
+              <option value="">Select</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+            </select>
+            <button id="btnSubmitRating" type="button" class="rounded-lg border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-900 hover:bg-slate-50">Submit</button>
+          </div>
+          <button id="btnReport" type="button" class="rounded-xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 shadow-sm hover:bg-rose-100">
+            Report
+          </button>
         </div>
-        {% else %}
-        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-          <div class="text-xs font-semibold text-slate-600">mina · 2h ago</div>
-          <div class="mt-2">This route is perfect for weekends!</div>
-        </div>
-        <div class="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-          <div class="text-xs font-semibold text-slate-600">alex · 1h ago</div>
-          <div class="mt-2">Could add one more sunset spot.</div>
-        </div>
-        {% endfor %}
       </div>
+
+      <div class="text-sm font-semibold text-slate-900">Comments</div>
+      <p class="mt-1 text-sm text-slate-600">Leave a comment</p>
+
+      <div class="mt-4 space-y-3" id="commentList"></div>
 
       <div class="mt-4">
         <label class="text-sm font-medium text-slate-700" for="cmt">Add comment</label>
         <textarea
           id="cmt"
           class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none ring-sky-500/30 focus:ring-4"
-          placeholder="Mock input only (no submit logic)"
+          placeholder="Write your comment"
           rows="3"
         ></textarea>
         <button id="btnCmt" type="button"
@@ -104,6 +113,12 @@
         </button>
       </div>
     </aside>
+  </section>
+
+  <section class="mt-6 rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
+    <h2 class="text-lg font-semibold text-slate-900">Similar routes</h2>
+    <p class="mt-1 text-sm text-slate-600">Based on theme and tags</p>
+    <div id="similarRoutes" class="mt-4 grid gap-3 md:grid-cols-2"></div>
   </section>
 </main>
 {% endblock %}


### PR DESCRIPTION
## Goal

Add route cover image support with upload, edit, and remove functionality, while providing a default cover image fallback when no custom cover is uploaded.

## Changes

- Added route cover image upload functionality
- Implemented remove and edit logic for route covers
- Aligned route cover behavior with existing location photo management logic
- Added default route cover fallback support
- Updated frontend rendering and route image handling logic

## Acceptance Criterion

- Users can upload route cover images successfully
- Users can edit or remove uploaded route covers
- Routes display a default cover image when no custom cover is provided
- Route cover functionality behaves consistently with location photo handling
- Existing route functionality continues to work correctly

## Need to Polish
- Optimize default cover rendering consistency across pages

Closes #82 