### PR TITLE
Security/auth middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 import secrets
 
 from flask import Flask, abort, jsonify, redirect, render_template, request, session, url_for
-from functools import wraps
+from auth import get_current_user, login_required, get_template_globals
 from sqlalchemy import text
 from werkzeug.utils import secure_filename
 
@@ -22,13 +22,37 @@ from route_service import (
 from utils import check_password, hash_password
 
 app = Flask(__name__)
-app.secret_key = "myvibe-dev-secret-change-in-production"
+
+# ---------------------------------------------------------------------------
+# Security configuration — load from .env file or environment variables
+# ---------------------------------------------------------------------------
+
+# Load .env file manually if it exists (no extra dependencies needed)
+_env_path = os.path.join(os.path.dirname(__file__), ".env")
+if os.path.exists(_env_path):
+    with open(_env_path) as _f:
+        for _line in _f:
+            _line = _line.strip()
+            if _line and not _line.startswith("#") and "=" in _line:
+                _key, _val = _line.split("=", 1)
+                os.environ.setdefault(_key.strip(), _val.strip())
+
+_secret = os.environ.get("FLASK_SECRET_KEY", "").strip()
+if not _secret:
+    _secret = "myvibe-dev-secret-change-in-production"
+
+app.secret_key = _secret
+
+# Session cookie hardening
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["PERMANENT_SESSION_LIFETIME"] = 60 * 60 * 24 * 7   # 7 days
 
 # ---------------------------------------------------------------------------
 # Database configuration
 # ---------------------------------------------------------------------------
 
-app.config["SQLALCHEMY_DATABASE_URI"]        = "sqlite:///myvibe.db"
+app.config["SQLALCHEMY_DATABASE_URI"]        = os.environ.get("DATABASE_URL", "sqlite:///myvibe.db")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db.init_app(app)
@@ -104,52 +128,17 @@ THEMES = ["first date", "picnic", "active day", "hidden gems"]
 # Auth helpers
 # ---------------------------------------------------------------------------
 
-def current_user():
-    """Return the logged-in User object from session, or None."""
-    user_id = session.get("user_id")
-    if not user_id:
-        return None
-    return User.query.get(user_id)
+# current_user moved to auth.py
+current_user = get_current_user
 
 
 @app.context_processor
 def inject_template_globals():
-    """
-    Inject shared variables into every template:
-    - current_user    : User object or None
-    - server_username : username string for legacy templates
-    - myvibe_bootstrap: auth state dict for JS
-    - unread_count    : unread notification count for nav badge
-    """
-    user = current_user()
-
-    unread_count = 0
-    if user:
-        unread_count = Notification.query.filter_by(
-            recipient_id = user.id,
-            is_read      = False,
-        ).count()
-
-    return {
-        "current_user":    user,
-        "server_username": user.username if user else None,
-        "myvibe_bootstrap": {
-            "isAuthenticated": user is not None,
-            "username":        user.username if user else None,
-            "userId":          user.id if user else None,
-        },
-        "unread_count": unread_count,
-    }
+    """Inject shared auth variables into every template. Logic lives in auth.py."""
+    return get_template_globals()
 
 
-def login_required(f):
-    """Redirect unauthenticated requests to the login page."""
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        if session.get("user_id") is None:
-            return redirect(url_for("login"))
-        return f(*args, **kwargs)
-    return decorated
+# login_required moved to auth.py
 
 # ---------------------------------------------------------------------------
 # Auth routes

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,57 @@
+"""
+auth.py — Centralised session-based authentication middleware.
+Issue #34: Extracted from app.py for separation of concerns.
+"""
+
+from functools import wraps
+from flask import session, redirect, url_for, request, jsonify
+from models import User, Notification
+
+
+def get_current_user():
+    """Return the logged-in User object from session, or None."""
+    user_id = session.get("user_id")
+    if not user_id:
+        return None
+    return User.query.get(user_id)
+
+
+def login_required(f):
+    """
+    Decorator: redirect unauthenticated page requests to login.
+    For API routes (URL starts with /api/), returns a 401 JSON response instead.
+    """
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if session.get("user_id") is None:
+            if request.path.startswith("/api/"):
+                return jsonify(ok=False, error="Authentication required."), 401
+            return redirect(url_for("login"))
+        return f(*args, **kwargs)
+    return decorated
+
+
+def get_template_globals():
+    """
+    Returns shared variables injected into every template via context_processor.
+    Includes: current_user, server_username, myvibe_bootstrap, unread_count.
+    """
+    user = get_current_user()
+
+    unread_count = 0
+    if user:
+        unread_count = Notification.query.filter_by(
+            recipient_id=user.id,
+            is_read=False,
+        ).count()
+
+    return {
+        "current_user":    user,
+        "server_username": user.username if user else None,
+        "myvibe_bootstrap": {
+            "isAuthenticated": user is not None,
+            "username":        user.username if user else None,
+            "userId":          user.id if user else None,
+        },
+        "unread_count": unread_count,
+    }


### PR DESCRIPTION
## Changes
- Created `auth.py` as a dedicated authentication middleware module
- Moved `current_user()`, `login_required()`, and template globals into `auth.py`
- `login_required` now returns 401 JSON for `/api/` routes instead of redirecting
- `app.py` imports from `auth.py` for cleaner separation of concerns
- Secret key loaded from `FLASK_SECRET_KEY` environment variable
- Added session cookie hardening: HttpOnly, SameSite=Lax, 7-day lifetime
- Added `.env.example` as a safe template for local setup

## Related Issue
Part of #34